### PR TITLE
Add color palette to plugin settings to change background color

### DIFF
--- a/include/ignition/gui/qml/IgnCard.qml
+++ b/include/ignition/gui/qml/IgnCard.qml
@@ -75,9 +75,9 @@ Pane {
   property string closeIcon: "\u2715"
 
   /**
-   * The plugin backgroung color
+   * The plugin backgroung color. Default: transparent
    */
-  property string cardBackground: "#ffffff"
+  property string cardBackground: "#00000000"
 
   /**
    *

--- a/include/ignition/gui/qml/IgnCard.qml
+++ b/include/ignition/gui/qml/IgnCard.qml
@@ -75,6 +75,11 @@ Pane {
   property string closeIcon: "\u2715"
 
   /**
+   * The plugin backgroung color
+   */
+  property string cardBackground: "#ffffff"
+
+  /**
    *
    */
   property var backgroundItem: null
@@ -446,7 +451,7 @@ Pane {
     anchors.fill: parent
     anchors.topMargin: card.showTitleBar ? 50 : 0
     clip: true
-    color: "transparent"
+    color: cardBackground
 
     onChildrenChanged: {
       card.syncTheFamily()

--- a/include/ignition/gui/qml/IgnCardSettings.qml
+++ b/include/ignition/gui/qml/IgnCardSettings.qml
@@ -90,7 +90,7 @@ Dialog {
           width: 50
           height: 30
           id: "bgColor"
-          color: "transparent"
+          color: cardBackground
           border.color: "#000000"
           border.width: 2
         }
@@ -201,6 +201,7 @@ Dialog {
     onAccepted: {
       content.color = colorDialog.color
       bgColor.color = colorDialog.color
+      cardBackground = colorDialog.color
     }
     onRejected: {
       console.log("Canceled")

--- a/include/ignition/gui/qml/IgnCardSettings.qml
+++ b/include/ignition/gui/qml/IgnCardSettings.qml
@@ -18,6 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import QtQuick.Window 2.2
+import QtQuick.Dialogs 1.0
 import "qrc:/qml"
 
 Dialog {
@@ -71,6 +72,31 @@ Dialog {
         card.resizable = checked
       }
     }
+
+    GridLayout {
+      width: parent.width
+      columns: 3
+      visible: !card.standalone
+
+      Label {
+        text: "Background Color "
+      }
+
+      Button {
+        Layout.preferredWidth: parent.width * 0.4
+        onClicked: colorDialog.open()
+        background: Rectangle {
+          y: 8
+          width: 50
+          height: 30
+          id: "bgColor"
+          color: "transparent"
+          border.color: "#000000"
+          border.width: 2
+        }
+      }
+    }
+
 
     GridLayout {
       width: parent.width
@@ -166,5 +192,19 @@ Dialog {
         text: "Height"
       }
     }
+  }
+
+  ColorDialog {
+    id: colorDialog
+    title: "Please choose a color"
+    showAlphaChannel : true
+    onAccepted: {
+      content.color = colorDialog.color
+      bgColor.color = colorDialog.color
+    }
+    onRejected: {
+      console.log("Canceled")
+    }
+    Component.onCompleted: visible = false
   }
 }


### PR DESCRIPTION
Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>

Reference to issue #61 

### Description
Add color palette to select background color and transparency to the plugin settings. User can change the background in both docked and undocked state.

![split](https://user-images.githubusercontent.com/33201532/81652771-e09f0080-9451-11ea-8f1a-7e4bfc8b856a.jpg)


### Basic Info
Tested on: Ubuntu 18.04