### PR TITLE
Fixed left menu events

### DIFF
--- a/examples/standalone/custom_drawer/CustomDrawer.qml
+++ b/examples/standalone/custom_drawer/CustomDrawer.qml
@@ -47,18 +47,18 @@ Rectangle {
     // Custom action which calls custom C++ code
     ListElement {
       title: "Call C++ action"
-      action: "cppActionFromQml"
+      action_element: "cppActionFromQml"
     }
 
     // Actions provided by Ignition GUI, with custom titles
     ListElement {
       title: "Call default action (Style)"
-      action: "styleSettings"
+      action_element: "styleSettings"
     }
 
     ListElement {
       title: "Call default action (Quit)"
-      action: "close"
+      action_element: "close"
     }
   }
 
@@ -73,7 +73,7 @@ Rectangle {
       text: title
       highlighted: ListView.isCurrentItem
       onClicked: {
-        customDrawer.onAction(action);
+        customDrawer.onAction(action_element);
         customDrawer.parent.closeDrawer();
       }
     }

--- a/examples/standalone/custom_drawer/CustomDrawer.qml
+++ b/examples/standalone/custom_drawer/CustomDrawer.qml
@@ -47,18 +47,18 @@ Rectangle {
     // Custom action which calls custom C++ code
     ListElement {
       title: "Call C++ action"
-      action_element: "cppActionFromQml"
+      actionElement: "cppActionFromQml"
     }
 
     // Actions provided by Ignition GUI, with custom titles
     ListElement {
       title: "Call default action (Style)"
-      action_element: "styleSettings"
+      actionElement: "styleSettings"
     }
 
     ListElement {
       title: "Call default action (Quit)"
-      action_element: "close"
+      actionElement: "close"
     }
   }
 
@@ -73,7 +73,7 @@ Rectangle {
       text: title
       highlighted: ListView.isCurrentItem
       onClicked: {
-        customDrawer.onAction(action_element);
+        customDrawer.onAction(actionElement);
         customDrawer.parent.closeDrawer();
       }
     }

--- a/include/ignition/gui/qml/SideDrawer.qml
+++ b/include/ignition/gui/qml/SideDrawer.qml
@@ -63,27 +63,27 @@ Drawer {
 
       ListElement {
         title: "Load configuration"
-        action_element: "loadConfig"
+        actionElement: "loadConfig"
       }
       ListElement {
         title: "Save configuration"
-        action_element: "saveConfig"
+        actionElement: "saveConfig"
       }
       ListElement {
         title: "Save configuration as"
-        action_element: "saveConfigAs"
+        actionElement: "saveConfigAs"
       }
       ListElement {
         title: "Style settings"
-        action_element: "styleSettings"
+        actionElement: "styleSettings"
       }
       ListElement {
         title: "About"
-        action_element: "aboutDialog"
+        actionElement: "aboutDialog"
       }
       ListElement {
         title: "Quit"
-        action_element: "close"
+        actionElement: "close"
       }
     }
 
@@ -97,7 +97,7 @@ Drawer {
         text: title
         highlighted: ListView.isCurrentItem
         onClicked: {
-          sideDrawer.onAction(action_element)
+          sideDrawer.onAction(actionElement)
           sideDrawer.closeDrawer();
         }
       }

--- a/include/ignition/gui/qml/SideDrawer.qml
+++ b/include/ignition/gui/qml/SideDrawer.qml
@@ -63,27 +63,27 @@ Drawer {
 
       ListElement {
         title: "Load configuration"
-        action: "loadConfig"
+        action_element: "loadConfig"
       }
       ListElement {
         title: "Save configuration"
-        action: "saveConfig"
+        action_element: "saveConfig"
       }
       ListElement {
         title: "Save configuration as"
-        action: "saveConfigAs"
+        action_element: "saveConfigAs"
       }
       ListElement {
         title: "Style settings"
-        action: "styleSettings"
+        action_element: "styleSettings"
       }
       ListElement {
         title: "About"
-        action: "aboutDialog"
+        action_element: "aboutDialog"
       }
       ListElement {
         title: "Quit"
-        action: "close"
+        action_element: "close"
       }
     }
 
@@ -97,7 +97,7 @@ Drawer {
         text: title
         highlighted: ListView.isCurrentItem
         onClicked: {
-          sideDrawer.onAction(action)
+          sideDrawer.onAction(action_element)
           sideDrawer.closeDrawer();
         }
       }


### PR DESCRIPTION
In Ubuntu 20.04 the lef menu is not working. 

![fail-gazebo](https://user-images.githubusercontent.com/1933907/85331905-482b7f80-b4d7-11ea-8ed2-430c2871ddac.gif)

Probably because the keyword action is reserved. With this small fix the menu is working again.

Signed-off-by: ahcorde <ahcorde@gmail.com>