### PR TITLE
Fixed ImageDisplay in Ubuntu 20.04

### DIFF
--- a/include/ignition/gui/qml/IgnCard.qml
+++ b/include/ignition/gui/qml/IgnCard.qml
@@ -119,7 +119,7 @@ Pane {
   /**
    * ID within QML
    */
-  id: card
+  id: cardPane
 
   /**
    * Object name accessible from C++
@@ -152,7 +152,7 @@ Pane {
     // but I haven't figured out yet how the card can tell IgnSplit to create
     // a new split and add the card to it. There must be a way using signals, events
     // or global functions...?
-    var bgItemTemp = helpers.ancestorByName(card, "background")
+    var bgItemTemp = helpers.ancestorByName(cardPane, "background")
     if (bgItemTemp)
       backgroundItem = bgItemTemp;
 
@@ -165,7 +165,7 @@ Pane {
    * any knowledge of splits
    */
   function syncTheFamily() {
-    var parentSplit = helpers.ancestorByName(card, /^split_item/);
+    var parentSplit = helpers.ancestorByName(cardPane, /^split_item/);
 
     if (undefined == parentSplit)
       return;
@@ -181,14 +181,14 @@ Pane {
    * Clear all anchors
    */
   function clearAnchors() {
-    card.anchors.right = undefined
-    card.anchors.left = undefined
-    card.anchors.top = undefined
-    card.anchors.bottom = undefined
-    card.anchors.fill = undefined
-    card.anchors.horizontalCenter = undefined
-    card.anchors.verticalCenter = undefined
-    card.anchors.baseline = undefined
+    cardPane.anchors.right = undefined
+    cardPane.anchors.left = undefined
+    cardPane.anchors.top = undefined
+    cardPane.anchors.bottom = undefined
+    cardPane.anchors.fill = undefined
+    cardPane.anchors.horizontalCenter = undefined
+    cardPane.anchors.verticalCenter = undefined
+    cardPane.anchors.baseline = undefined
 
     anchored = false
   }
@@ -260,7 +260,7 @@ Pane {
     var splitItem = backgroundItem.childItems[splitName];
 
     // Reparent to split
-    card.parent = splitItem;
+    cardPane.parent = splitItem;
   }
 
   /**
@@ -269,12 +269,12 @@ Pane {
   function enterFloatingState()
   {
     // Reparent to main window's background
-    card.parent = backgroundItem
+    cardPane.parent = backgroundItem
 
     // Resize to minimum size
-    card.clearAnchors();
-    card.width = content.children[0].Layout.minimumWidth;
-    card.height = content.children[0].Layout.minimumHeight;
+    cardPane.clearAnchors();
+    cardPane.width = content.children[0].Layout.minimumWidth;
+    cardPane.height = content.children[0].Layout.minimumHeight;
   }
 
   /**
@@ -283,7 +283,7 @@ Pane {
   function leaveDockedState()
   {
     // Remove from split (delete split if needed)
-    backgroundItem.removeSplitItem(helpers.ancestorByName(card,
+    backgroundItem.removeSplitItem(helpers.ancestorByName(cardPane,
         /^split_item/).objectName)
   }
 
@@ -301,8 +301,8 @@ Pane {
 //   */
 //  Window {
 //    // TODO: resize
-//    width: card.width;
-//    height: card.height;
+//    width: cardPane.width;
+//    height: cardPane.height;
 //    visible: false;
 //    id: cardWindow
 //
@@ -312,7 +312,7 @@ Pane {
 //    }
 //
 //    onClosing: {
-//      card.state = "docked"
+//      cardPane.state = "docked"
 //    }
 //  }
 
@@ -322,11 +322,11 @@ Pane {
   ToolBar {
     id: cardToolbar
     objectName: "cardToolbar"
-    visible: card.showTitleBar
+    visible: cardPane.showTitleBar
     Material.foreground: Material.foreground
     Material.background: pluginToolBarColor
-    width: card.width
-    height: card.showTitleBar ? 50 : 0
+    width: cardPane.width
+    height: cardPane.showTitleBar ? 50 : 0
     x: 0
     z: 100
 
@@ -334,11 +334,11 @@ Pane {
     MouseArea {
       anchors.fill: parent
       drag {
-        target: card
+        target: cardPane
         minimumX: 0
         minimumY: 0
-        maximumX: card.parent ? card.parent.width - card.width : card.width
-        maximumY: card.parent ? card.parent.height - card.height : card.height
+        maximumX: cardPane.parent ? cardPane.parent.width - cardPane.width : cardPane.width
+        maximumY: cardPane.parent ? cardPane.parent.height - cardPane.height : cardPane.height
         smoothed: true
       }
     }
@@ -365,37 +365,37 @@ Pane {
       // TODO(louise) support window state
       ToolButton {
         id: dockButton
-        text: card.state === "docked" ? floatIcon : dockIcon
+        text: cardPane.state === "docked" ? floatIcon : dockIcon
         contentItem: Text {
           text: dockButton.text
           font: dockButton.font
           opacity: enabled ? 1.0 : 0.3
-          color: card.Material.background
+          color: cardPane.Material.background
           horizontalAlignment: Text.AlignHCenter
           verticalAlignment: Text.AlignVCenter
         }
-        visible: card.showDockButton && !card.standalone
+        visible: cardPane.showDockButton && !cardPane.standalone
         onClicked: {
-          const docked = card.state === "docked"
-          card.state = docked ? "floating" : "docked"
+          const docked = cardPane.state === "docked"
+          cardPane.state = docked ? "floating" : "docked"
         }
       }
 
       // Close button
       ToolButton {
         id: closeButton
-        visible: card.showCloseButton && !card.standalone
+        visible: cardPane.showCloseButton && !cardPane.standalone
         text: closeIcon
         contentItem: Text {
           text: closeButton.text
           font: closeButton.font
           opacity: enabled ? 1.0 : 0.3
-          color: card.Material.background
+          color: cardPane.Material.background
           horizontalAlignment: Text.AlignHCenter
           verticalAlignment: Text.AlignVCenter
         }
         onClicked: {
-          card.close();
+          cardPane.close();
         }
       }
     }
@@ -417,11 +417,11 @@ Pane {
     transformOrigin: Menu.TopRight
     MenuItem {
       text: "Settings"
-      onTriggered: card.showSettingsDialog();
+      onTriggered: cardPane.showSettingsDialog();
     }
     MenuItem {
       text: "Close"
-      onTriggered: card.close();
+      onTriggered: cardPane.close();
     }
   }
 
@@ -437,7 +437,7 @@ Pane {
     modal: false
     focus: true
     title: pluginName + " settings"
-    parent: card.parent
+    parent: cardPane.parent
     x: parent ? (parent.width - width) / 2 : 0
     y: parent ? (parent.height - height) / 2 : 0
   }
@@ -449,26 +449,26 @@ Pane {
     objectName: "content"
     id: content
     anchors.fill: parent
-    anchors.topMargin: card.showTitleBar ? 50 : 0
+    anchors.topMargin: cardPane.showTitleBar ? 50 : 0
     clip: true
     color: cardBackground
 
     onChildrenChanged: {
-      card.syncTheFamily()
+      cardPane.syncTheFamily()
     }
 
     /**
      * Conveniently expose card to children
      */
     function card() {
-      return card;
+      return cardPane;
     }
   }
 
   IgnRulers {
     anchors.fill: parent
-    enabled: card.state === "floating" && resizable
-    minSize: card.minSize
-    target: card
+    enabled: cardPane.state === "floating" && resizable
+    minSize: cardPane.minSize
+    target: cardPane
   }
 }

--- a/include/ignition/gui/qml/IgnCardSettings.qml
+++ b/include/ignition/gui/qml/IgnCardSettings.qml
@@ -32,9 +32,9 @@ Dialog {
     Switch {
       id: titleSwitch
       text: "Show title bar"
-      checked: card.showTitleBar
+      checked: cardPane.showTitleBar
       onToggled: {
-        card.showTitleBar = checked
+        cardPane.showTitleBar = checked
         // why is binding not working?
         closeSwitch.enabled = checked
         dockSwitch.enabled = checked
@@ -44,39 +44,39 @@ Dialog {
     Switch {
       id: closeSwitch
       text: "Show close button"
-      visible: !card.standalone
-      enabled: card.showTitleBar
-      checked: card.showCloseButton
+      visible: !cardPane.standalone
+      enabled: cardPane.showTitleBar
+      checked: cardPane.showCloseButton
       onToggled: {
-        card.showCloseButton = checked
+        cardPane.showCloseButton = checked
       }
     }
 
     Switch {
       id: dockSwitch
       text: "Show dock button"
-      visible: !card.standalone
-      enabled: card.showTitleBar
-      checked: card.showDockButton
+      visible: !cardPane.standalone
+      enabled: cardPane.showTitleBar
+      checked: cardPane.showDockButton
       onToggled: {
-        card.showDockButton = checked
+        cardPane.showDockButton = checked
       }
     }
 
     Switch {
       id: resizableSwitch
       text: "Resizable"
-      visible: card.state === "floating"
-      checked: card.resizable
+      visible: cardPane.state === "floating"
+      checked: cardPane.resizable
       onToggled: {
-        card.resizable = checked
+        cardPane.resizable = checked
       }
     }
 
     GridLayout {
       width: parent.width
       columns: 3
-      visible: !card.standalone
+      visible: !cardPane.standalone
 
       Label {
         text: "Background Color "
@@ -101,7 +101,7 @@ Dialog {
     GridLayout {
       width: parent.width
       columns: 2
-      visible: card.state === "floating"
+      visible: cardPane.state === "floating"
 
       Label {
         text: "Position"
@@ -114,48 +114,48 @@ Dialog {
 
       // TODO(louise) Support setting anchors from the dialog
       Button {
-        visible: card.anchored
+        visible: cardPane.anchored
         text: "Clear anchors"
         Layout.columnSpan: 2
         onClicked: {
-          card.clearAnchors()
+          cardPane.clearAnchors()
         }
       }
 
       IgnSpinBox {
-        visible: !card.anchored
-        maximumValue: card.parent ? card.parent.width - card.width : minSize
-        onVisibleChanged: value = card.x
+        visible: !cardPane.anchored
+        maximumValue: cardPane.parent ? cardPane.parent.width - cardPane.width : minSize
+        onVisibleChanged: value = cardPane.x
         onValueChanged: {
-          card.x = value;
+          cardPane.x = value;
         }
       }
       Label {
-        visible: !card.anchored
+        visible: !cardPane.anchored
         text: "X"
       }
       IgnSpinBox {
-        visible: !card.anchored
-        maximumValue: card.parent ? card.parent.height - card.height : minSize
-        onVisibleChanged: value = card.y
+        visible: !cardPane.anchored
+        maximumValue: cardPane.parent ? cardPane.parent.height - cardPane.height : minSize
+        onVisibleChanged: value = cardPane.y
         onValueChanged: {
-          card.y = value;
+          cardPane.y = value;
         }
       }
       Label {
-        visible: !card.anchored
+        visible: !cardPane.anchored
         text: "Y"
       }
       IgnSpinBox {
-        visible: !card.anchored
+        visible: !cardPane.anchored
         maximumValue: 10000
-        onVisibleChanged: value = card.z
+        onVisibleChanged: value = cardPane.z
         onValueChanged: {
-          card.z = value;
+          cardPane.z = value;
         }
       }
       Label {
-        visible: !card.anchored
+        visible: !cardPane.anchored
         text: "Z"
       }
       Label {
@@ -166,26 +166,26 @@ Dialog {
         text: ""
       }
       IgnSpinBox {
-        maximumValue: card.parent ? card.parent.width : minSize
+        maximumValue: cardPane.parent ? cardPane.parent.width : minSize
         onVisibleChanged: {
-          if (card)
-            value = card.width
+          if (cardPane)
+            value = cardPane.width
         }
         onValueChanged: {
-          card.width = value;
+          cardPane.width = value;
         }
       }
       Label {
         text: "Width"
       }
       IgnSpinBox {
-        maximumValue: card.parent ? card.parent.height : minSize
+        maximumValue: cardPane.parent ? cardPane.parent.height : minSize
         onVisibleChanged: {
-          if (card)
-            value = card.height
+          if (cardPane)
+            value = cardPane.height
         }
         onValueChanged: {
-          card.height = value;
+          cardPane.height = value;
         }
       }
       Label {


### PR DESCRIPTION
I was not able to visualize images with the ign gui display in Ubuntu 20.04.

Something happens using the same name for the `id` and for the function `card()`. I renamed the variable `card` to `cardPane`, with this change images are shown again with ImageDisplay Plugin.

Signed-off-by: ahcorde <ahcorde@gmail.com>