### PR TITLE
Update deps for Dome: use msgs6, transport9

### DIFF
--- a/.github/ci-bionic/after_make.sh
+++ b/.github/ci-bionic/after_make.sh
@@ -4,3 +4,8 @@ set -x
 
 # Install (needed for some tests)
 make install
+
+Xvfb :1 -screen 0 1280x1024x24 &
+export DISPLAY=:1.0
+export RENDER_ENGINE_VALUES=ogre2
+export MESA_GL_VERSION_OVERRIDE=3.3

--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -31,10 +31,10 @@ jobs:
             libignition-cmake2-dev
             libignition-common3-dev
             libignition-math6-dev
-            libignition-msgs5-dev
+            libignition-msgs6-dev
             libignition-plugin-dev
             libignition-tools-dev
-            libignition-transport8-dev
+            libignition-transport9-dev
             libogre-1.9-dev
             libogre-2.1-dev
             libglew-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-transport
-ign_find_package(ignition-transport8 REQUIRED)
-set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
+ign_find_package(ignition-transport9 REQUIRED)
+set(IGN_TRANSPORT_VER ${ignition-transport9_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering
@@ -64,8 +64,8 @@ set(IGN_RENDERING_VER ${ignition-rendering4_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-msgs
-ign_find_package(ignition-msgs5 REQUIRED)
-set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
+ign_find_package(ignition-msgs6 REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-tools

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ On Ubuntu Bionic, it's possible to install Ignition GUI's version 1 as follows:
 
 Add OSRF packages:
 
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-stable.list
+    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list
     sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
     sudo apt update
 
@@ -147,8 +148,8 @@ line is using symbolic links to each library's YAML file.
 mkdir ~/.ignition/tools/configs -p
 cd ~/.ignition/tools/configs/
 ln -s /usr/local/share/ignition/fuel4.yaml .
-ln -s /usr/local/share/ignition/transport7.yaml .
-ln -s /usr/local/share/ignition/transportlog7.yaml .
+ln -s /usr/local/share/ignition/transport9.yaml .
+ln -s /usr/local/share/ignition/transportlog9.yaml .
 ...
 export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 ```


### PR DESCRIPTION
As part of the works of ignition-tooling/gazebodistro#5 bump the use of msgs to major version 6 and transport to 9