### PR TITLE
Add shift + drag to rotate camera

### DIFF
--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -865,7 +865,10 @@ void IgnRenderer::HandleMouseEvent()
     // Pan with left button
     if (this->dataPtr->mouseEvent.Buttons() & common::MouseEvent::LEFT)
     {
-      this->dataPtr->viewControl.Pan(this->dataPtr->drag);
+      if (Qt::ShiftModifier == QGuiApplication::queryKeyboardModifiers())
+        this->dataPtr->viewControl.Orbit(this->dataPtr->drag);
+      else
+        this->dataPtr->viewControl.Pan(this->dataPtr->drag);
     }
     // Orbit with middle button
     else if (this->dataPtr->mouseEvent.Buttons() & common::MouseEvent::MIDDLE)


### PR DESCRIPTION
I am adding the recent changes in `ign-gazebo`'s Scene3D plugin to rotate the camera using shift + drag to `ign-gui`'s Scene3D plugin. Thank you @mohamedsayed18 for this feature.