### PR TITLE
Scroll bar adjustment

### DIFF
--- a/include/ignition/gui/qml/IgnSplit.qml
+++ b/include/ignition/gui/qml/IgnSplit.qml
@@ -289,13 +289,17 @@ SplitView {
        */
       property var split: split
 
-      // Offset of 17 to accomodate for ScrollView scroll bar
-      Layout.minimumWidth: split.Layout.minimumWidth + 17
+      /**
+       * Offset of 17 to accommodate for ScrollView scroll bar
+       */
+      property var scrollBarWidth: 17
+
+      Layout.minimumWidth: split.Layout.minimumWidth + scrollBarWidth
       Layout.minimumHeight: split.Layout.minimumHeight
 
       ScrollView {
         contentHeight: split.height
-        contentWidth: split.width + 17
+        contentWidth: split.width + scrollBarWidth
 
         ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
@@ -304,7 +308,7 @@ SplitView {
 
         SplitView {
           id: split
-          width: splitWrapper.width0
+          width: splitWrapper.width - scrollBarWidth
           height: Math.max(childItems[Object.keys(childItems)[0]].height,
                       split.Layout.minimumHeight)
 

--- a/include/ignition/gui/qml/IgnSplit.qml
+++ b/include/ignition/gui/qml/IgnSplit.qml
@@ -289,19 +289,22 @@ SplitView {
        */
       property var split: split
 
-      Layout.minimumWidth: split.Layout.minimumWidth
+      // Offset of 17 to accomodate for ScrollView scroll bar
+      Layout.minimumWidth: split.Layout.minimumWidth + 17
       Layout.minimumHeight: split.Layout.minimumHeight
 
       ScrollView {
         contentHeight: split.height
-        contentWidth: split.width
+        contentWidth: split.width + 17
+
+        ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
         // TODO(louise) This only works for a very specific split
         height: window.height - window.header.height
 
         SplitView {
           id: split
-          width: splitWrapper.width
+          width: splitWrapper.width0
           height: Math.max(childItems[Object.keys(childItems)[0]].height,
                       split.Layout.minimumHeight)
 


### PR DESCRIPTION
Closes https://github.com/ignitionrobotics/ign-gazebo/issues/99

Fixes a pre-existing issue with the scroll bar for the overall plugin side bar interfering with each plugin's individual scroll bar.  I made the overall scroll bar visible, and made a small space on the right hand side for it to reside.

![scrollbar](https://user-images.githubusercontent.com/8881852/88852840-b1bc3f00-d1a3-11ea-865f-e2f59f59d7a6.gif)
