### PR TITLE
Fix Grid3D plugin

### DIFF
--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -16,10 +16,11 @@
 */
 import QtQuick 2.0
 import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
 
 Rectangle {
-  width: 100
-  height: 100
+  Layout.minimumWidth: 100
+  Layout.minimumHeight: 100
 }
 
 


### PR DESCRIPTION
I didn't notice this before but with #84 in action, there was no option to interact with Grid3D plugin GUI (especially closing it). And because it was always a child of the split, there was also no option to close the split after adding a Grid3D plugin.