### PR TITLE
Disable TopicViewer_TEST on Windows and macOS

### DIFF
--- a/src/plugins/topic_viewer/TopicViewer_TEST.cc
+++ b/src/plugins/topic_viewer/TopicViewer_TEST.cc
@@ -37,6 +37,8 @@ using namespace ignition;
 using namespace gui;
 using namespace plugins;
 
+// See https://github.com/ignitionrobotics/ign-gui/issues/75
+#if not defined(__APPLE__) && not defined(_WIN32)
 /////////////////////////////////////////////////
 TEST(TopicViewerTest, Load)
 {
@@ -191,3 +193,4 @@ TEST(TopicViewerTest, Model)
 
     EXPECT_EQ(root->rowCount(), 2);
 }
+#endif


### PR DESCRIPTION
See #75.

I thought we could wait for #76 to be merged forward to disable the test, but on Windows the compilation was broken.