### PR TITLE
Use world name in default topics

### DIFF
--- a/include/ignition/gui/Helpers.hh
+++ b/include/ignition/gui/Helpers.hh
@@ -70,6 +70,15 @@ namespace ignition
     std::string uniqueFilePath(const std::string &_pathAndName,
                                const std::string &_extension);
 
+    /// \brief The main window's "worldNames" property may be filled with a list
+    /// of the names of all worlds currently loaded. This information can be
+    /// used by plugins to choose which world to work with.
+    /// This helper function provides a handy access to the world names list.
+    /// \return List of world names, as stored in the `MainWindow`'s
+    /// "worldNames" property.
+    IGNITION_GUI_VISIBLE
+    QStringList worldNames();
+
     /// \brief Returns the first element on a QList which matches the given
     /// property.
     /// \param[in] _list The list to search through.

--- a/include/ignition/gui/qml/IgnCard.qml
+++ b/include/ignition/gui/qml/IgnCard.qml
@@ -115,6 +115,7 @@ Pane {
    * Tool bar background color
    */
   property string pluginToolBarColor:
+    typeof MainWindow === "undefined" ||
     MainWindow.pluginToolBarColorLight === "" ||
     MainWindow.pluginToolBarColorDark === "" ?
     Material.accent :
@@ -125,6 +126,7 @@ Pane {
    * Tool bar text color
    */
   property string pluginToolBarTextColor:
+    typeof MainWindow === "undefined" ||
     MainWindow.pluginToolBarTextColorLight === "" ||
     MainWindow.pluginToolBarTextColorDark === "" ?
     Material.background :

--- a/src/Helpers.cc
+++ b/src/Helpers.cc
@@ -20,8 +20,10 @@
 #include <string>
 #include <ignition/math/Helpers.hh>
 
+#include "ignition/gui/Application.hh"
 #include "ignition/gui/Enums.hh"
 #include "ignition/gui/Helpers.hh"
+#include "ignition/gui/MainWindow.hh"
 
 /////////////////////////////////////////////////
 std::string ignition::gui::humanReadable(const std::string &_key)
@@ -163,4 +165,18 @@ std::string ignition::gui::uniqueFilePath(const std::string &_pathAndName,
   }
 
   return result;
+}
+
+/////////////////////////////////////////////////
+QStringList ignition::gui::worldNames()
+{
+  auto win = App()->findChild<MainWindow *>();
+  if (nullptr == win)
+    return {};
+
+  auto worldNamesVariant = win->property("worldNames");
+  if (!worldNamesVariant.isValid())
+    return {};
+
+  return worldNamesVariant.toStringList();
 }

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -146,7 +146,8 @@ TEST(HelpersTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(findFirstByProperty))
 }
 
 /////////////////////////////////////////////////
-TEST(HelpersTest, worldNames)
+// See https://github.com/ignitionrobotics/ign-gui/issues/75
+TEST(HelpersTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(worldNames))
 {
   // No app, no window, no names
   EXPECT_TRUE(worldNames().empty());

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -23,6 +23,7 @@
 
 #include "test_config.h"  // NOLINT(build/include)
 #include "ignition/gui/Application.hh"
+#include "ignition/gui/MainWindow.hh"
 #include "ignition/gui/Helpers.hh"
 
 int gg_argc = 1;
@@ -142,4 +143,32 @@ TEST(HelpersTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(findFirstByProperty))
   EXPECT_EQ(findFirstByProperty(list, "banana", 2.0), o1);
   EXPECT_EQ(findFirstByProperty(list, "banana", 3.0), nullptr);
   EXPECT_EQ(findFirstByProperty(list, "acerola", 1.0), nullptr);
+}
+
+/////////////////////////////////////////////////
+TEST(HelpersTest, worldNames)
+{
+  // No app, no window, no names
+  EXPECT_TRUE(worldNames().empty());
+
+  Application app(gg_argc, gg_argv);
+  auto mainWindow = app.findChild<MainWindow *>();
+  ASSERT_NE(nullptr, mainWindow);
+
+  // No names by default
+  EXPECT_TRUE(worldNames().empty());
+
+  QStringList names{"banana", "grape"};
+  mainWindow->setProperty("worldNames", names);
+
+  // Has names
+  EXPECT_FALSE(worldNames().empty());
+  ASSERT_EQ(2, worldNames().size());
+  EXPECT_EQ("banana", worldNames()[0]);
+  EXPECT_EQ("grape", worldNames()[1]);
+
+  mainWindow->setProperty("worldNames", QStringList());
+
+  // No more names
+  EXPECT_TRUE(worldNames().empty());
 }

--- a/src/plugins/topic_echo/TopicEcho.qml
+++ b/src/plugins/topic_echo/TopicEcho.qml
@@ -84,8 +84,8 @@ Rectangle {
     }
 
     Rectangle {
-      width: topicEcho.parent.width - 20
-      height: topicEcho.parent.height - 200
+      width: topicEcho.parent !== null ? topicEcho.parent.width - 20 : 50
+      height: topicEcho.parent !== null ? topicEcho.parent.height - 200 : 50
       color: "transparent"
 
       ListView {

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -16,8 +16,10 @@
 */
 
 #include <ignition/common/Console.hh>
-#include <ignition/plugin/Register.hh>
 #include <ignition/common/Time.hh>
+#include <ignition/plugin/Register.hh>
+
+#include "ignition/gui/Helpers.hh"
 
 #include "WorldControl.hh"
 
@@ -80,6 +82,12 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     return;
   }
 
+  // World name from window, to construct default topics and services
+  std::string worldName;
+  auto worldNames = gui::worldNames();
+  if (!worldNames.empty())
+    worldName = worldNames[0].toStdString();
+
   // For world control requests
   auto serviceElem = _pluginElem->FirstChildElement("service");
   if (nullptr != serviceElem && nullptr != serviceElem->GetText())
@@ -87,10 +95,18 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
   if (this->dataPtr->controlService.empty())
   {
-    ignerr << "Must specify a service for world control requests."
-           << std::endl;
-    return;
+    if (worldName.empty())
+    {
+      ignerr << "Must specify a <service> for world control requests, or set "
+             << "the MainWindow's [worldNames] property." << std::endl;
+      return;
+    }
+
+    this->dataPtr->controlService = "/world/" + worldName + "/control";
   }
+
+  ignmsg << "Using world control service [" << this->dataPtr->controlService
+         << "]" << std::endl;
 
   // Play / pause buttons
   if (auto playElem = _pluginElem->FirstChildElement("play_pause"))
@@ -128,6 +144,11 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   if (nullptr != statsTopicElem && nullptr != statsTopicElem->GetText())
     statsTopic = statsTopicElem->GetText();
 
+  if (statsTopic.empty() && !worldName.empty())
+  {
+    statsTopic = "/world/" + worldName + "/stats";
+  }
+
   if (!statsTopic.empty())
   {
     // Subscribe to world_stats
@@ -135,6 +156,10 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         &WorldControl::OnWorldStatsMsg, this))
     {
       ignerr << "Failed to subscribe to [" << statsTopic << "]" << std::endl;
+    }
+    else
+    {
+      ignmsg << "Listening to stats on [" << statsTopic << "]" << std::endl;
     }
   }
 }


### PR DESCRIPTION
Goes with https://github.com/ignitionrobotics/ign-gazebo/pull/278.

This adds support for retrieving world names from the main window and makes use of that on the `WorldControl` and `WorldStats` plugins.

This doesn't change the default behaviour of those plugins. Their `<topic>`s and `<service>`s will still be respected. But now we default to `/world/<world name>/something` topics if nothing is set.

---

I was afraid of bringing `ign-gazebo`'s concept of worlds to `ign-gui` when it doesn't need it. But considering that this concept is already built into the 2 plugins in question and is completely optional to all other plugins, I thought this was something reasonable to bring here.