### PR TITLE
Removed repeated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ which can be used to add custom widgets.
 
 # Install
 
-Review the [tutorial section](https://ignitionrobotics.org/api/gui/3.2/install.html).
+See the [installation tutorial](https://ignitionrobotics.org/api/gui/3.2/install.html).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ which can be used to add custom widgets.
 
 [Install](#install)
 
-* [Binary Install](#binary-install)
-
-* [Source Install](#source-install)
-
-    * [Prerequisites](#prerequisites)
-
-    * [Building from Source](#building-from-source)
-
 [Usage](#usage)
 
 [Documentation](#documentation)
@@ -60,66 +52,7 @@ which can be used to add custom widgets.
 
 # Install
 
-We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
-
-The [Source Install](#source-install) instructions should be used if you need the very latest software improvements, if you need to modify the code, or if you plan to make a contribution.
-
-## Binary Install
-
-On Ubuntu Bionic, it's possible to install Ignition GUI's version 1 as follows:
-
-Add OSRF packages:
-
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list
-    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
-    sudo apt update
-
-Install Ignition GUI:
-
-    sudo apt install libignition-gui4-dev
-
-## Source Install
-
-There are currently two versions under active development:
-
-* **Version 0**: It makes use of `QWidgets`, which are common on traditional
-  desktop-oriented interfaces. Requires Ubuntu Xenial or Higher.
-
-* **Version 1**: It makes use of `QtQuick`, which allows developing more
-  modern-looking apps with animations and a mobile/web feel. Requires Ubuntu
-  Bionic or higher.
-
-### Prerequisites
-
-#### Ubuntu Bionic 18.04 or above
-
-Install dependencies:
-
-    sudo apt update
-    sudo apt -y install wget lsb-release gnupg
-    sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-    sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
-    wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
-    sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main"
-    sudo apt-get build-dep -y ignition-gui4
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-
-Clone source code:
-
-    # This checks out the `default` branch. You can append `-b ign-gui#` (replace # with a number) to checkout a specific version
-    git clone http://github.com/ignitionrobotics/ign-gui
-
-### Building from source
-
-Build and install as follows:
-
-    cd ign-gui
-    mkdir build
-    cd build
-    cmake ..
-    make -j4
-    sudo make install
+Review the [tutorial section](tutorials/01_install.md).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ which can be used to add custom widgets.
 
 # Install
 
-Review the [tutorial section](tutorials/01_install.md).
+Review the [tutorial section](https://ignitionrobotics.org/api/gui/3.2/install.html).
 
 # Usage
 

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -2,5 +2,75 @@
 
 Next Tutorial: \ref commandline
 
-Refer to [Ignition GUI's entry page](https://ignitionrobotics.org/libs/gui)
-for install instructions.
+[Install](#install)
+
+* [Binary Install](#binary-install)
+
+* [Source Install](#source-install)
+
+    * [Prerequisites](#prerequisites)
+
+    * [Building from Source](#building-from-source)
+
+# Install
+
+We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
+
+The [Source Install](#source-install) instructions should be used if you need the very latest software improvements, if you need to modify the code, or if you plan to make a contribution.
+
+## Binary Install
+
+On Ubuntu Bionic, it's possible to install Ignition GUI's version 1 as follows:
+
+Add OSRF packages:
+
+    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list
+    sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+    sudo apt update
+
+Install Ignition GUI:
+
+    sudo apt install libignition-gui4-dev
+
+## Source Install
+
+There are currently two versions under active development:
+
+* **Version 0**: It makes use of `QWidgets`, which are common on traditional
+  desktop-oriented interfaces. Requires Ubuntu Xenial or Higher.
+
+* **Version 1**: It makes use of `QtQuick`, which allows developing more
+  modern-looking apps with animations and a mobile/web feel. Requires Ubuntu
+  Bionic or higher.
+
+### Prerequisites
+
+#### Ubuntu Bionic 18.04 or above
+
+Install dependencies:
+
+    sudo apt update
+    sudo apt -y install wget lsb-release gnupg
+    sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+    sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
+    wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+    sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main"
+    sudo apt-get build-dep -y ignition-gui4
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+
+Clone source code:
+
+    # This checks out the `default` branch. You can append `-b ign-gui#` (replace # with a number) to checkout a specific version
+    git clone http://github.com/ignitionrobotics/ign-gui
+
+### Building from source
+
+Build and install as follows:
+
+    cd ign-gui
+    mkdir build
+    cd build
+    cmake ..
+    make -j4
+    sudo make install

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -20,25 +20,24 @@ The [Source Install](#source-install) instructions should be used if you need th
 
 ## Binary Install
 
-On Ubuntu Bionic, it's possible to install Ignition GUI's version 1 as follows:
+On Ubuntu Bionic, it's possible to install Ignition GUI as follows:
 
 Add OSRF packages:
 
     echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-    echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list
     sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
     sudo apt update
 
 Install Ignition GUI:
 
-    sudo apt install libignition-gui4-dev
+    sudo apt install libignition-gui<#>-dev
+
+Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
+which version you need.
 
 ## Source Install
 
 There are currently two versions under active development:
-
-* **Version 0**: It makes use of `QWidgets`, which are common on traditional
-  desktop-oriented interfaces. Requires Ubuntu Xenial or Higher.
 
 * **Version 1**: It makes use of `QtQuick`, which allows developing more
   modern-looking apps with animations and a mobile/web feel. Requires Ubuntu
@@ -53,7 +52,6 @@ Install dependencies:
     sudo apt update
     sudo apt -y install wget lsb-release gnupg
     sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-    sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
     sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main"
     sudo apt-get build-dep -y ignition-gui4

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -20,7 +20,7 @@ The [Source Install](#source-install) instructions should be used if you need th
 
 ## Binary Install
 
-On Ubuntu Bionic, it's possible to install Ignition GUI as follows:
+On Ubuntu, it's possible to install Ignition GUI as follows:
 
 Add OSRF packages:
 
@@ -36,12 +36,6 @@ Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
 which version you need.
 
 ## Source Install
-
-There are currently two versions under active development:
-
-* **Version 1**: It makes use of `QtQuick`, which allows developing more
-  modern-looking apps with animations and a mobile/web feel. Requires Ubuntu
-  Bionic or higher.
 
 ### Prerequisites
 
@@ -59,7 +53,7 @@ Install dependencies:
 
 Clone source code:
 
-    # This checks out the `default` branch. You can append `-b ign-gui#` (replace # with a number) to checkout a specific version
+    # This checks out the `master` branch. You can append `-b ign-gui#` (replace # with a number) to checkout a specific version
     git clone http://github.com/ignitionrobotics/ign-gui
 
 ### Building from source


### PR DESCRIPTION
This PR is related with this issue https://github.com/ignitionrobotics/docs/issues/14

Moved install instructions to the tutorials folder.

Signed-off-by: ahcorde <ahcorde@gmail.com>