### PR TITLE
Fix running plugins with bad world name

### DIFF
--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -171,7 +171,7 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   {
     ignwarn << "Ignoring topic [" << statsTopic
             << "], world name different from [" << worldName
-            << "]. Fix or remove your <service> tag." << std::endl;
+            << "]. Fix or remove your <stats_topic> tag." << std::endl;
 
     statsTopic = "/world/" + worldName + "/stats";
   }

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -17,6 +17,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Time.hh>
+#include <ignition/common/StringUtils.hh>
 #include <ignition/plugin/Register.hh>
 
 #include "ignition/gui/Helpers.hh"
@@ -93,6 +94,22 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   if (nullptr != serviceElem && nullptr != serviceElem->GetText())
     this->dataPtr->controlService = serviceElem->GetText();
 
+  // Service specified with different world name
+  auto parts = common::Split(this->dataPtr->controlService, '/');
+  if (parts.size() == 4 &&
+      parts[0] == "" &&
+      parts[1] == "world" &&
+      parts[2] != worldName &&
+      parts[3] == "control")
+  {
+    ignwarn << "Ignoring service [" << this->dataPtr->controlService
+            << "], world name different from [" << worldName
+            << "]. Fix or remove your <service> tag." << std::endl;
+
+    this->dataPtr->controlService = "/world/" + worldName + "/control";
+  }
+
+  // Service unspecified, use world name
   if (this->dataPtr->controlService.empty())
   {
     if (worldName.empty())
@@ -143,6 +160,21 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   auto statsTopicElem = _pluginElem->FirstChildElement("stats_topic");
   if (nullptr != statsTopicElem && nullptr != statsTopicElem->GetText())
     statsTopic = statsTopicElem->GetText();
+
+  // Service specified with different world name
+  parts = common::Split(statsTopic, '/');
+  if (parts.size() == 4 &&
+      parts[0] == "" &&
+      parts[1] == "world" &&
+      parts[2] != worldName &&
+      parts[3] == "stats")
+  {
+    ignwarn << "Ignoring topic [" << statsTopic
+            << "], world name different from [" << worldName
+            << "]. Fix or remove your <service> tag." << std::endl;
+
+    statsTopic = "/world/" + worldName + "/stats";
+  }
 
   if (statsTopic.empty() && !worldName.empty())
   {

--- a/src/plugins/world_control/WorldControl.hh
+++ b/src/plugins/world_control/WorldControl.hh
@@ -51,8 +51,12 @@ namespace plugins
   /// * \<play_pause\> : Set to true to see a play/pause and step buttons,
   ///                    false by default.
   /// * \<start_paused\> : Set to false to start playing, false by default.
-  /// * \<service\> : Service for world control, required.
-  /// * \<stats_topic\> : Topic to receive world statistics, optional.
+  /// * \<service\> : Service for world control, optional. If not presnt,
+  ///               the plugin will attempt to create a topic with the main
+  ///               window's `worldName` property.
+  /// * \<stats_topic\> : Topic to receive world statistics, optional. If not
+  ///               present, the plugin will attempt to create a topic with the
+  ///               main window's `worldName` property.
   class WorldControl_EXPORTS_API WorldControl: public ignition::gui::Plugin
   {
     Q_OBJECT

--- a/src/plugins/world_control/WorldControl_TEST.cc
+++ b/src/plugins/world_control/WorldControl_TEST.cc
@@ -126,3 +126,108 @@ TEST(WorldControlTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldControl))
   // Cleanup
   plugins.clear();
 }
+
+/////////////////////////////////////////////////
+TEST(WorldControlTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldNameNoService))
+{
+  common::Console::SetVerbosity(4);
+
+  Application app(g_argc, g_argv);
+  app.AddPluginPath(std::string(PROJECT_BINARY_PATH) + "/lib");
+
+  // Get main window
+  auto win = app.findChild<MainWindow *>();
+  ASSERT_NE(nullptr, win);
+
+  QStringList names{"banana", "grape"};
+  win->setProperty("worldNames", names);
+
+  // Load plugin
+  const char *pluginStr =
+    "<plugin filename=\"WorldControl\">"
+    "</plugin>";
+
+  tinyxml2::XMLDocument pluginDoc;
+  EXPECT_EQ(tinyxml2::XML_SUCCESS, pluginDoc.Parse(pluginStr));
+  EXPECT_TRUE(app.LoadPlugin("WorldControl",
+      pluginDoc.FirstChildElement("plugin")));
+
+  // Show, but don't exec, so we don't block
+  win->QuickWindow()->show();
+
+  // Get plugin
+  auto plugins = win->findChildren<plugins::WorldControl *>();
+  EXPECT_EQ(plugins.size(), 1);
+
+  // World control service
+  bool pauseCalled = false;
+  std::function<bool(const msgs::WorldControl &, msgs::Boolean &)> cb =
+      [&](const msgs::WorldControl &_req, msgs::Boolean &)
+  {
+    pauseCalled = _req.pause();
+    return true;
+  };
+  transport::Node node;
+  node.Advertise("/world/banana/control", cb);
+
+  // Pause
+  plugins[0]->OnPause();
+  EXPECT_TRUE(pauseCalled);
+
+  // Cleanup
+  plugins.clear();
+}
+
+/////////////////////////////////////////////////
+TEST(WorldControlTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldNameBadService))
+{
+  common::Console::SetVerbosity(4);
+
+  Application app(g_argc, g_argv);
+  app.AddPluginPath(std::string(PROJECT_BINARY_PATH) + "/lib");
+
+  // Get main window
+  auto win = app.findChild<MainWindow *>();
+  ASSERT_NE(nullptr, win);
+
+  QStringList names{"banana", "grape"};
+  win->setProperty("worldNames", names);
+
+  // Load plugin
+  const char *pluginStr =
+    "<plugin filename=\"WorldControl\">"
+    "  <service>/world/watermelon/control</service>"
+    "</plugin>";
+
+  tinyxml2::XMLDocument pluginDoc;
+  EXPECT_EQ(tinyxml2::XML_SUCCESS, pluginDoc.Parse(pluginStr));
+  EXPECT_TRUE(app.LoadPlugin("WorldControl",
+      pluginDoc.FirstChildElement("plugin")));
+
+  // Show, but don't exec, so we don't block
+  win->QuickWindow()->show();
+
+  // Get plugin
+  auto plugins = win->findChildren<plugins::WorldControl *>();
+  EXPECT_EQ(plugins.size(), 1);
+
+  // World control service
+  bool pauseCalled = false;
+  std::function<bool(const msgs::WorldControl &, msgs::Boolean &)> cb =
+      [&](const msgs::WorldControl &_req, msgs::Boolean &)
+  {
+    pauseCalled = _req.pause();
+    return true;
+  };
+  transport::Node node;
+
+  // banana, not watermelon
+  node.Advertise("/world/banana/control", cb);
+
+  // Pause
+  plugins[0]->OnPause();
+  EXPECT_TRUE(pauseCalled);
+
+  // Cleanup
+  plugins.clear();
+}

--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -108,7 +108,7 @@ void WorldStats::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   {
     ignwarn << "Ignoring topic [" << topic
             << "], world name different from [" << worldName
-            << "]. Fix or remove your <service> tag." << std::endl;
+            << "]. Fix or remove your <topic> tag." << std::endl;
 
     topic = "/world/" + worldName + "/stats";
   }

--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -16,6 +16,7 @@
 */
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/StringUtils.hh>
 #include <ignition/common/Time.hh>
 #include <ignition/plugin/Register.hh>
 
@@ -96,6 +97,21 @@ void WorldStats::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   auto topicElem = _pluginElem->FirstChildElement("topic");
   if (nullptr != topicElem && nullptr != topicElem->GetText())
     topic = topicElem->GetText();
+
+  // Service specified with different world name
+  auto parts = common::Split(topic, '/');
+  if (parts.size() == 4 &&
+      parts[0] == "" &&
+      parts[1] == "world" &&
+      parts[2] != worldName &&
+      parts[3] == "stats")
+  {
+    ignwarn << "Ignoring topic [" << topic
+            << "], world name different from [" << worldName
+            << "]. Fix or remove your <service> tag." << std::endl;
+
+    topic = "/world/" + worldName + "/stats";
+  }
 
   if (topic.empty())
   {

--- a/src/plugins/world_stats/WorldStats.hh
+++ b/src/plugins/world_stats/WorldStats.hh
@@ -56,7 +56,9 @@ namespace plugins
   /// * \<real_time\> : True to display a real time widget, false by default.
   /// * \<real_time_factor\> : True to display a real time factor widget,
   ///                          false by default.
-  /// * \<topic\> : Topic to receive world statistics, required.
+  /// * \<topic\> : Topic to receive world statistics, optional. If not present,
+  ///               the plugin will attempt to create a topic with the main
+  ///               window's `worldName` property.
   class WorldStats_EXPORTS_API WorldStats: public ignition::gui::Plugin
   {
     Q_OBJECT

--- a/src/plugins/world_stats/WorldStats_TEST.cc
+++ b/src/plugins/world_stats/WorldStats_TEST.cc
@@ -170,3 +170,124 @@ TEST(WorldStatsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldStats))
   EXPECT_EQ(plugin->RealTime().toStdString(), "01 00:00:00.001");
   EXPECT_EQ(plugin->RealTimeFactor().toStdString(), "100.00 %");
 }
+
+/////////////////////////////////////////////////
+TEST(WorldStatsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldNameNoTopic))
+{
+  common::Console::SetVerbosity(4);
+
+  Application app(g_argc, g_argv);
+  app.AddPluginPath(std::string(PROJECT_BINARY_PATH) + "/lib");
+
+  // Get main window
+  auto win = app.findChild<MainWindow *>();
+  ASSERT_NE(nullptr, win);
+
+  QStringList names{"banana", "grape"};
+  win->setProperty("worldNames", names);
+
+  // Load plugin
+  const char *pluginStr =
+    "<plugin filename=\"WorldStats\">"
+    "  <sim_time>true</sim_time>"
+    "</plugin>";
+
+  tinyxml2::XMLDocument pluginDoc;
+  pluginDoc.Parse(pluginStr);
+  EXPECT_TRUE(app.LoadPlugin("WorldStats",
+      pluginDoc.FirstChildElement("plugin")));
+
+  // Show, but don't exec, so we don't block
+  win->QuickWindow()->show();
+
+  // Get plugin
+  auto plugin = win->findChild<plugins::WorldStats *>();
+  ASSERT_NE(nullptr, plugin);
+
+  // Publish stats
+  transport::Node node;
+  auto pub = node.Advertise<msgs::WorldStatistics>("/world/banana/stats");
+
+  // Sim time
+  {
+    msgs::WorldStatistics msg;
+    auto simTimeMsg = msg.mutable_sim_time();
+    simTimeMsg->set_sec(3600);
+    simTimeMsg->set_nsec(123456789);
+    msg.set_paused(true);
+    pub.Publish(msg);
+  }
+
+  // Give it time to be processed
+  int sleep = 0;
+  int maxSleep = 30;
+  while (plugin->SimTime() == "N/A" && sleep < maxSleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    QCoreApplication::processEvents();
+    sleep++;
+  }
+
+  EXPECT_EQ(plugin->SimTime().toStdString(), "00 01:00:00.123");
+}
+
+/////////////////////////////////////////////////
+TEST(WorldStatsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldNameBadTopic))
+{
+  common::Console::SetVerbosity(4);
+
+  Application app(g_argc, g_argv);
+  app.AddPluginPath(std::string(PROJECT_BINARY_PATH) + "/lib");
+
+  // Get main window
+  auto win = app.findChild<MainWindow *>();
+  ASSERT_NE(nullptr, win);
+
+  QStringList names{"banana", "grape"};
+  win->setProperty("worldNames", names);
+
+  // Load plugin
+  const char *pluginStr =
+    "<plugin filename=\"WorldStats\">"
+    "  <sim_time>true</sim_time>"
+    "  <topic>/world/watermelon/stats</topic>"
+    "</plugin>";
+
+  tinyxml2::XMLDocument pluginDoc;
+  pluginDoc.Parse(pluginStr);
+  EXPECT_TRUE(app.LoadPlugin("WorldStats",
+      pluginDoc.FirstChildElement("plugin")));
+
+  // Show, but don't exec, so we don't block
+  win->QuickWindow()->show();
+
+  // Get plugin
+  auto plugin = win->findChild<plugins::WorldStats *>();
+  ASSERT_NE(nullptr, plugin);
+
+  // Publish stats
+  transport::Node node;
+  auto pub = node.Advertise<msgs::WorldStatistics>("/world/banana/stats");
+
+  // Sim time
+  {
+    msgs::WorldStatistics msg;
+    auto simTimeMsg = msg.mutable_sim_time();
+    simTimeMsg->set_sec(3600);
+    simTimeMsg->set_nsec(123456789);
+    msg.set_paused(true);
+    pub.Publish(msg);
+  }
+
+  // Give it time to be processed
+  int sleep = 0;
+  int maxSleep = 30;
+  while (plugin->SimTime() == "N/A" && sleep < maxSleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    QCoreApplication::processEvents();
+    sleep++;
+  }
+
+  EXPECT_EQ(plugin->SimTime().toStdString(), "00 01:00:00.123");
+}


### PR DESCRIPTION
An unforeseen consequence of #104 + https://github.com/ignitionrobotics/ign-gazebo/pull/278 is that users who already had old `~/.ignition/gazebo/gui.config` files wouldn't be able to load the worlds that now have no `<gui>` element, because of the topic mismatch.

So this PR adds a check and ignores topics and services that are explicitly defined, but don't match `worldName`.

For example, when the user has `<topic>/world/default/stats</topic>` on their `gui.config`, and tries to load `shapes.sdf`, we load the plugin with the correct `/world/shapes/stats` topic, and print a warning.