### PR TITLE
Small tweaks to the plot plugin

### DIFF
--- a/include/ignition/gui/qml/Chart.qml
+++ b/include/ignition/gui/qml/Chart.qml
@@ -515,6 +515,8 @@ Rectangle {
     */
     function appendPoint(_fieldID, _x, _y)
     {
+      if (!chart.serieses[_fieldID])
+        return;
 
       // if this is the first point (if the chart is empty):
       // set the min/max according to that point's coordinates

--- a/src/plugins/plotting/TransportPlotting.cc
+++ b/src/plugins/plotting/TransportPlotting.cc
@@ -29,7 +29,7 @@ TransportPlotting::~TransportPlotting()
 void TransportPlotting::LoadConfig(const tinyxml2::XMLElement *)
 {
   if (this->title.empty())
-    this->title = "Plotting";
+    this->title = "Transport plotting";
 }
 
 //////////////////////////////////////////


### PR DESCRIPTION
Just a couple of tweaks that I noticed while reviewing https://github.com/ignitionrobotics/ign-gazebo/pull/270/:

* The check in `Chart.qml` is needed to avoid warnings after a field is deleted from a plot
* Changed the title of the transport plotting plugin so it's different from the one in `ign-gazebo`.

@AmrElsersy , mind taking a look?