### PR TITLE
Fix qt5 anchor warnings

### DIFF
--- a/src/plugins/world_control/WorldControl.qml
+++ b/src/plugins/world_control/WorldControl.qml
@@ -90,7 +90,7 @@ RowLayout {
     visible: showPlay
     text: paused ? playIcon : pauseIcon
     checkable: true
-    anchors.verticalCenter: parent.verticalCenter
+    Layout.alignment : Qt.AlignVCenter
     Layout.minimumWidth: width
     Layout.leftMargin: 10
     onClicked: {


### PR DESCRIPTION
Same as the [ign-gazebo PR](https://github.com/ignitionrobotics/ign-gazebo/pull/363), fixes the QT5 warnings at simulation starting time caused by the WorldControl plugin:

```
[ign-8] [GUI] [Wrn] [Application.cc:649] [QT] file::/WorldControl/WorldControl.qml:88:3: QML RoundButton: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
```