### PR TITLE
Updates to README and installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Ignition Robotics contributing guide](https://ignitionrobotics.org/docs/all/contributing).
+See the [Ignition contributing guide](https://ignitionrobotics.org/docs/all/contributing).

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ which can be used to add custom widgets.
 
 [Documentation](#documentation)
 
-[Testing](#testing)
-
 [Folder Structure](#folder-structure)
 
 [Code of Conduct](#code-of-conduct)
@@ -52,7 +50,7 @@ which can be used to add custom widgets.
 
 # Install
 
-See the [installation tutorial](https://ignitionrobotics.org/api/gui/3.2/install.html).
+See the [installation tutorial](https://ignitionrobotics.org/api/gui/4.0/install.html).
 
 # Usage
 
@@ -88,16 +86,6 @@ export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 ```
 
 This issue is tracked [here](https://github.com/ignitionrobotics/ign-tools/issues/8).
-
-# Testing
-
-After building, to run all tests:
-
-    cd build
-    make test
-
-See [this tutorial](https://ignitionrobotics.org/api/gui/4.0/install.html) for
-further instructions on how to disable testing, run test coverage, etc.
 
 # Folder Structure
 
@@ -139,7 +127,7 @@ Please see
 
 # Versioning
 
-This library uses [Semantic Versioning](https://semver.org/). Additionally, this library is part of the [Ignition Robotics project](https://ignitionrobotics.org) which periodically releases a versioned set of compatible and complimentary libraries. See the [Ignition Robotics website](https://ignitionrobotics.org) for version and release information.
+This library uses [Semantic Versioning](https://semver.org/). Additionally, this library is part of the [Ignition project](https://ignitionrobotics.org) which periodically releases a versioned set of compatible and complimentary libraries. See the [Ignition website](https://ignitionrobotics.org) for version and release information.
 
 # License
 

--- a/api.md.in
+++ b/api.md.in
@@ -1,7 +1,7 @@
 ## Ignition @IGN_DESIGNATION_CAP@
 
-Ignition @IGN_DESIGNATION_CAP@ is a component in Ignition Robotics, a set of libraries
-designed to rapidly develop robot and simulation applications. 
+Ignition @IGN_DESIGNATION_CAP@ is a component in Ignition, a set of libraries
+designed to rapidly develop robot and simulation applications.
 
 ## License
 

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -2,23 +2,22 @@
 
 Next Tutorial: \ref commandline
 
-[Install](#install)
-
-* [Binary Install](#binary-install)
-
-* [Source Install](#source-install)
-
-    * [Prerequisites](#prerequisites)
-
-    * [Building from Source](#building-from-source)
-
 # Install
 
-We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
+These instructions are for installing only Ignition GUI. If you're interested
+in using all the Ignition libraries, not only Igniton GUI, check out this
+[Ignition installation](https://ignitionrobotics.org/docs/latest/install).
 
-The [Source Install](#source-install) instructions should be used if you need the very latest software improvements, if you need to modify the code, or if you plan to make a contribution.
+We recommend following the binary install instructions to get up and running as
+quickly and painlessly as possible.
+
+The source install instructions should be used if you need the very latest
+software improvements, if you need to modify the code, or if you plan to make a
+contribution.
 
 ## Binary Install
+
+### Ubuntu
 
 On Ubuntu, it's possible to install Ignition GUI as follows:
 
@@ -35,26 +34,47 @@ Install Ignition GUI:
 Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
 which version you need.
 
+### macOS
+
+On macOS, add OSRF packages:
+
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    brew tap osrf/simulation
+
+Install Ignition GUI:
+
+    brew install ignition-gui<#>
+
+Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
+which version you need.
+
 ## Source Install
 
 ### Prerequisites
 
 #### Ubuntu Bionic 18.04 or above
 
-Install dependencies:
+Add OSRF packages:
 
     sudo apt update
     sudo apt -y install wget lsb-release gnupg
     sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
     wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
     sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main"
-    sudo apt-get build-dep -y ignition-gui4
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 
 Clone source code:
 
     # This checks out the `master` branch. You can append `-b ign-gui#` (replace # with a number) to checkout a specific version
     git clone http://github.com/ignitionrobotics/ign-gui
+
+Install dependencies
+
+   sudo apt -y install $(sort -u $(find . -iname 'packages.apt') | tr '\n' ' ')
+
+Only on Bionic, update the GCC compiler version:
+
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+
 
 ### Building from source
 
@@ -66,3 +86,59 @@ Build and install as follows:
     cmake ..
     make -j4
     sudo make install
+
+# Documentation
+
+API documentation and tutorials can be accessed at
+[https://ignitionrobotics.org/libs/gui](https://ignitionrobotics.org/libs/gui)
+
+You can also generate the documentation from a clone of this repository by following these steps.
+
+1. You will need [Doxygen](http://www.doxygen.org/). On Ubuntu Doxygen can be installed using
+
+    ```
+    sudo apt-get install doxygen
+    ```
+
+2. Clone the repository
+
+    ```
+    git clone https://github.com/ignitionrobotics/ign-gui
+    ```
+
+3. Configure and build the documentation.
+
+    ```
+    cd ign-gui
+    mkdir build
+    cd build
+    cmake ../
+    make doc
+    ```
+
+4. View the documentation by running the following command from the `build` directory.
+
+    ```
+    firefox doxygen/html/index.html
+    ```
+
+# Testing
+
+Follow these steps to run tests and static code analysis in your clone of this repository.
+
+1. Follow the [source install instruction](#source-install).
+
+2. Run tests.
+
+    ```
+    make test
+    ```
+
+3. Static code checker.
+
+    ```
+    make codecheck
+    ```
+
+See the [Writing Tests section of the contributor guide](https://ignitionrobotics.org/docs/all/contributing#writing-tests) for help creating or modifying tests.
+


### PR DESCRIPTION
* Ignition Robotics -> Ignition
* Moved testing into the installation tutorial, because it's lost without context on the top page
* Added a link to the Ignition installation docs (related to https://github.com/ignitionrobotics/ign-gazebo/issues/124)
* Added documentation and code checker instructions
* Added Homebrew installation instructions