### PR TITLE
Publish plugin API docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(ignition-gui3 VERSION 3.3.0)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 REQUIRED)
+find_package(ignition-cmake2 2.3 REQUIRED)
 
 #============================================================================
 # Configure the project
@@ -110,6 +110,7 @@ configure_file(${CMAKE_SOURCE_DIR}/tutorials.md.in ${CMAKE_BINARY_DIR}/tutorials
 ign_create_docs(
   API_MAINPAGE_MD "${CMAKE_BINARY_DIR}/api.md"
   TUTORIALS_MAINPAGE_MD "${CMAKE_BINARY_DIR}/tutorials.md"
+  ADDITIONAL_INPUT_DIRS "${CMAKE_SOURCE_DIR}/src/plugins"
   TAGFILES
   "\"${CMAKE_SOURCE_DIR}/doc/qt.tag.xml=http://doc.qt.io/qt-5/\" \
    \"${IGNITION-MATH_DOXYGEN_TAGFILE} = ${IGNITION-MATH_API_URL}\" \

--- a/tutorials/03_plugins.md
+++ b/tutorials/03_plugins.md
@@ -20,7 +20,7 @@ Ignition GUI will look for plugins on the following paths, in this order:
 1. All paths set on the `IGN_GUI_PLUGIN_PATH` environment variable
 2. All paths added by calling `ignition::gui::addPluginPath`
 3. `~/.ignition/gui/plugins`
-4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/0.1/namespaceignition_1_1gui_1_1plugins.html)
+4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/3.3/namespaceignition_1_1gui_1_1plugins.html)
 
 ## Configuring plugins
 


### PR DESCRIPTION
Uses the feature introduced in https://github.com/ignitionrobotics/ign-cmake/pull/111 and released into `ign-cmake 2.3`.

This should make the link on the tutorial valid. This is what it looks like locally:

![image](https://user-images.githubusercontent.com/5751272/94326950-95970d00-ff5c-11ea-8627-6ea764389cd2.png)
