### PR TITLE
Add scrollable indicator for plugin menu

### DIFF
--- a/include/ignition/gui/qml/PluginMenu.qml
+++ b/include/ignition/gui/qml/PluginMenu.qml
@@ -44,8 +44,10 @@ Menu {
 
     model: MainWindow.PluginListModel()
 
-    ScrollIndicator.vertical: ScrollIndicator {
+    ScrollBar.vertical: ScrollBar {
       active: true
+      width: 8
+      policy: ScrollBar.AlwaysOn
     }
   }
 }


### PR DESCRIPTION
Reference to issue [ign-gazebo #368](https://github.com/ignitionrobotics/ign-gazebo/issues/368)