### PR TITLE
Floating and standalone plugins respect minimum dimensions

### DIFF
--- a/include/ignition/gui/qml/IgnCard.qml
+++ b/include/ignition/gui/qml/IgnCard.qml
@@ -112,6 +112,16 @@ Pane {
   property bool anchored: false
 
   /**
+   * Minimum width of the card pane
+   */
+  property int cardMinimumWidth: 250;
+
+  /**
+   * Minimum height of the card pane
+   */
+  property int cardMinimumHeight: 250;
+
+  /**
    * Tool bar background color
    */
   property string pluginToolBarColor:
@@ -653,6 +663,14 @@ Pane {
     color: cardBackground
 
     onChildrenChanged: {
+      // Set the height and width of the cardPane when child plugin is attached
+      if (children.length > 0) {
+        cardMinimumWidth = content.children[0].Layout.minimumWidth;
+        cardMinimumHeight = content.children[0].Layout.minimumHeight;
+        cardPane.width = cardMinimumWidth
+        cardPane.height = cardMinimumHeight
+      }
+
       cardPane.syncTheFamily()
     }
 

--- a/include/ignition/gui/qml/IgnRulers.qml
+++ b/include/ignition/gui/qml/IgnRulers.qml
@@ -228,7 +228,7 @@ Rectangle {
   {
     var newCardX = Math.max(target.x + mouseX, 0)
     var newCardWidth = Math.max(target.width + (target.x - newCardX),
-                                rulersRect.minSize)
+                                rulersRect.minSize, target.cardMinimumWidth)
 
     if (newCardWidth === target.width)
       return;
@@ -239,7 +239,8 @@ Rectangle {
 
   function resizeRight(target, mouseX)
   {
-    target.width = Math.max(target.width + mouseX, rulersRect.minSize)
+    target.width = Math.max(target.width + mouseX, rulersRect.minSize,
+                            target.cardMinimumWidth)
 
     if (target.width + target.x > target.parent.width)
       target.width = target.parent.width - target.x
@@ -249,7 +250,7 @@ Rectangle {
   {
     var newCardY = Math.max(target.y + mouseY, 0)
     var newCardHeight = Math.max(target.height + (target.y - newCardY),
-                                 rulersRect.minSize)
+                                 rulersRect.minSize, target.cardMinimumHeight)
 
     if (newCardHeight === target.height)
       return;
@@ -260,7 +261,8 @@ Rectangle {
 
   function resizeBottom(target, mouseY)
   {
-    target.height = Math.max(target.height + mouseY, rulersRect.minSize)
+    target.height = Math.max(target.height + mouseY, rulersRect.minSize,
+                             target.cardMinimumHeight)
 
     if (target.height + target.y > target.parent.height)
       target.height = target.parent.height - target.y

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -516,16 +516,16 @@ bool Application::InitializeDialogs()
 
     this->dataPtr->dialogs.push_back(dialog);
 
-    cardItem->setParentItem(dialog->RootItem());
-
     // Configure card
     cardItem->setProperty("standalone", true);
 
     // Configure dialog
     auto cardWidth = cardItem->property("width").toInt();
     auto cardHeight = cardItem->property("height").toInt();
-    dialog->QuickWindow()->setProperty("width", cardWidth);
-    dialog->QuickWindow()->setProperty("height", cardHeight);
+    dialog->QuickWindow()->setProperty("minimumWidth", cardWidth);
+    dialog->QuickWindow()->setProperty("minimumHeight", cardHeight);
+
+    cardItem->setParentItem(dialog->RootItem());
 
     // Signals
     this->dataPtr->mainWin->connect(cardItem, SIGNAL(close()),

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -411,9 +411,6 @@ QQuickItem *Plugin::CardItem() const
     return nullptr;
   }
 
-  // Add plugin to card content
-  this->dataPtr->pluginItem->setParentItem(cardContentItem);
-
   // Configure card
   cardItem->setProperty("pluginName",
       QString::fromStdString(this->Title()));
@@ -441,6 +438,9 @@ QQuickItem *Plugin::CardItem() const
     cardItem->setProperty("height",
         this->dataPtr->pluginItem->property("height").toInt());
   }
+
+  // Add plugin to card content
+  this->dataPtr->pluginItem->setParentItem(cardContentItem);
 
   this->dataPtr->cardItem = cardItem;
 


### PR DESCRIPTION
* Set parentItem after resizing the dialog

* Create minimum height and width card properties

* Set height and width of card on adding a child plugin

* Enforce minimum dimensions on floating plugin resize

Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>