### PR TITLE
Add qml-module-qtcharts dependency

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -12,6 +12,7 @@ libtinyxml2-dev
 qml-module-qt-labs-folderlistmodel
 qml-module-qt-labs-platform
 qml-module-qt-labs-settings
+qml-module-qtcharts
 qml-module-qtgraphicaleffects
 qml-module-qtqml-models2
 qml-module-qtquick-controls


### PR DESCRIPTION
That's needed for the plotting plugins.

Adding it to `packages.qml` should affect some CI builds and some install from source instructions.