### PR TITLE
⬆️  Bump main to 5.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui4 VERSION 4.0.0)
+project(ignition-gui5 VERSION 5.0.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build | Status
 Test coverage | [![codecov](https://codecov.io/gh/ignitionrobotics/ign-gui/branch/master/graph/badge.svg)](https://codecov.io/gh/ignitionrobotics/ign-gui/branch/master)
 Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-master-bionic-amd64)](https://build.osrfoundation.org/job/ignition_gui-ci-master-bionic-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-master-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_gui-ci-master-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gui-ign-4-win)](https://build.osrfoundation.org/job/ign_gui-ign-4-win)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gui-ci-win)](https://build.osrfoundation.org/job/ign_gui-ci-win)
 
 Ignition GUI builds on top of [Qt](https://www.qt.io/) to provide widgets which are
 useful when developing robotics applications, such as a 3D view, plots, dashboard, etc,

--- a/examples/plugin/custom_context_menu/CMakeLists.txt
+++ b/examples/plugin/custom_context_menu/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 find_package(ignition-common3 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/dialog_from_plugin/CMakeLists.txt
+++ b/examples/plugin/dialog_from_plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 find_package(ignition-common3 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/hello_plugin/CMakeLists.txt
+++ b/examples/plugin/hello_plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 find_package(ignition-common3 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/ign_components/CMakeLists.txt
+++ b/examples/plugin/ign_components/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package (Qt5
   REQUIRED
 )
 
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 find_package(ignition-common3 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/multiple_qml/CMakeLists.txt
+++ b/examples/plugin/multiple_qml/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 find_package(ignition-common3 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/standalone/custom_drawer/CMakeLists.txt
+++ b/examples/standalone/custom_drawer/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 
 QT5_ADD_RESOURCES(resources_RCC custom_drawer.qrc)
 

--- a/examples/standalone/dialogs/CMakeLists.txt
+++ b/examples/standalone/dialogs/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")
 

--- a/examples/standalone/window/CMakeLists.txt
+++ b/examples/standalone/window/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui4 REQUIRED)
+find_package(ignition-gui5 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")
 


### PR DESCRIPTION
The `ign-gui4` branch was created off `main` for the Dome release.

Now bumping `main` to version 5 so it may receive breaking changes.