### PR TITLE
Re-enable image.config test

### DIFF
--- a/test/integration/Examples_TEST.cc
+++ b/test/integration/Examples_TEST.cc
@@ -42,13 +42,6 @@ TEST(ExampleTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Configs))
   ignition::common::DirIter endIter;
   for (common::DirIter file(exampleConfigPath); file != endIter; ++file)
   {
-    // image.config is broken (issue #40)
-    if ((*file).find("image") != std::string::npos)
-    {
-      ignerr << "skipping " << *file << std::endl;
-      continue;
-    }
-
     Application app(g_argc, g_argv);
     app.AddPluginPath(std::string(PROJECT_BINARY_PATH) + "/lib");
 


### PR DESCRIPTION
Resolves #40 

I can't reproduce the test failure locally, hopefully it's working on CI as well, we'll see :crossed_fingers: 