### PR TITLE
Suggestions to #148

### DIFF
--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -18,6 +18,7 @@
 #define IGNITION_GUI_GUIEVENTS_HH_
 
 #include <QEvent>
+#include <string>
 #include <utility>
 #include <vector>
 #include <ignition/math/Vector3.hh>

--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -60,140 +60,143 @@ namespace ignition
         : QEvent(kType), xyz(_xyz), rpy(_rpy), scale(_scale)
         {
         }
-  
+
         /// \brief Get the XYZ snapping values.
         /// \return The XYZ snapping values.
-        public: math::Vector3d XYZ() const
+        public: math::Vector3d Position() const
         {
           return this->xyz;
         }
-  
+
         /// \brief Get the RPY snapping values.
         /// \return The RPY snapping values.
-        public: math::Vector3d RPY() const
+        public: math::Vector3d Rotation() const
         {
           return this->rpy;
         }
-  
+
         /// \brief Get the scale snapping values.
         /// \return The scale snapping values.
         public: math::Vector3d Scale() const
         {
           return this->scale;
         }
-  
+
         /// \brief The QEvent representing a snap event occurrence.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 1);
-  
+
         /// \brief XYZ snapping values in meters, these values must be positive.
         private: math::Vector3d xyz;
-  
-        /// \brief RPY snapping values in degrees, these values must be positive.
+
+        /// \brief RPY snapping values in degrees, these values must be
+        /// positive.
         private: math::Vector3d rpy;
-  
+
         /// \brief Scale snapping values - a multiplier of the current size,
         /// these values must be positive.
         private: math::Vector3d scale;
       };
 
-      /// \brief Event called to spawn a preview model.
-      /// Used by plugins that spawn models.
-      class SpawnPreviewModel : public QEvent
+      /// \brief Event called to spawn a resource, given its description as a
+      /// string.
+      class SpawnFromDescription : public QEvent
       {
         /// \brief Constructor
-        /// \param[in] _modelString The model's description as a string.
-        public: explicit SpawnPreviewModel(std::string &_modelString)
-            : QEvent(kType), modelString(_modelString)
+        /// \param[in] _string The resource's description as a string, such
+        /// as an SDF file.
+        public: explicit SpawnFromDescription(const std::string &_description)
+            : QEvent(kType), description(_description)
         {
         }
-  
+
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 2);
-  
-        /// \brief Get the string of the model.
-        /// \return The model string
-        public: std::string ModelString() const
+
+        /// \brief Get the string description of the resource.
+        /// \return The resource string
+        public: const std::string &Description() const
         {
-          return this->modelString;
+          return this->description;
         }
-  
-        /// \brief The string of the model to be previewed.
-        std::string modelString;
+
+        /// \brief The string of the resource to be spawned.
+        std::string description;
       };
-  
-      /// \brief Event called to spawn a preview resource, which takes the path
-      /// to s file. Used by plugins that spawn resources.
-      class SpawnPreviewPath : public QEvent
+
+      /// \brief Event called to spawn a resource, which takes the path
+      /// to its file.
+      class SpawnFromPath : public QEvent
       {
         /// \brief Constructor
         /// \param[in] _filePath The path to a file.
-        public: explicit SpawnPreviewPath(const std::string &_filePath)
+        public: explicit SpawnFromPath(const std::string &_filePath)
             : QEvent(kType), filePath(_filePath)
         {
         }
-  
+
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 3);
-  
+
         /// \brief Get the path of the file.
         /// \return The file path.
-        public: std::string FilePath() const
+        public: const std::string &FilePath() const
         {
           return this->filePath;
         }
-  
+
         /// \brief The path of file to be previewed.
         std::string filePath;
       };
-  
-      /// \brief Event which is called to broadcast the 3D coordinates of a user's
-      /// mouse hover within the scene.
+
+      /// \brief Event which is called to broadcast the 3D coordinates of a
+      /// user's mouse hover within the scene.
       class HoverToScene : public QEvent
       {
         /// \brief Constructor
-        /// \param[in] _point The point at which the mouse is hovering within the
-        /// scene
+        /// \param[in] _point The point at which the mouse is hovering within
+        /// the scene
         public: explicit HoverToScene(const math::Vector3d &_point)
             : QEvent(kType), point(_point)
         {
         }
-  
+
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 4);
-  
-        /// \brief Get the point within the scene over which the user is hovering.
+
+        /// \brief Get the point within the scene over which the user is
+        /// hovering.
         /// \return The 3D point
         public: math::Vector3d Point() const
         {
           return this->point;
         }
-  
+
         /// \brief The 3D point over which the user is hovering.
         private: math::Vector3d point;
       };
-  
-      /// \brief Event which is called to broadcast the 3D coordinates of a user's
-      /// left click within the scene.
+
+      /// \brief Event which is called to broadcast the 3D coordinates of a
+      /// user's left click within the scene.
       class LeftClickToScene : public QEvent
       {
         /// \brief Constructor
-        /// \param[in] _point The point which the user has left clicked within the
-        /// scene
+        /// \param[in] _point The point which the user has left clicked within
+        /// the scene
         public: explicit LeftClickToScene(const math::Vector3d &_point)
             : QEvent(kType), point(_point)
         {
         }
-  
+
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 5);
-  
+
         /// \brief Get the point within the scene that the user clicked.
         /// \return The 3D point.
         public: math::Vector3d Point() const
         {
           return this->point;
         }
-  
+
         /// \brief The 3D point that the user clicked within the scene.
         private: math::Vector3d point;
       };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set (gtest_sources
   Conversions_TEST
   DragDropModel_TEST
   Helpers_TEST
+  GuiEvents_TEST
   ign_TEST
   MainWindow_TEST
   Plugin_TEST

--- a/src/GuiEvents_TEST.cc
+++ b/src/GuiEvents_TEST.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_config.h"  // NOLINT(build/include)
+#include "ignition/gui/GuiEvents.hh"
+
+using namespace ignition;
+using namespace gui;
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, Render)
+{
+  events::Render event;
+
+  EXPECT_LT(QEvent::User, event.type());
+}
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, SnapIntervals)
+{
+  events::SnapIntervals event({1, 2, 3}, {4, 5, 6}, {7, 8, 9});
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_EQ(math::Vector3d(1, 2, 3), event.Position());
+  EXPECT_EQ(math::Vector3d(4, 5, 6), event.Rotation());
+  EXPECT_EQ(math::Vector3d(7, 8, 9), event.Scale());
+}
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, SpawnFromDescription)
+{
+  events::SpawnFromDescription event("banana");
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_EQ("banana", event.Description());
+}
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, SpawnFromPath)
+{
+  events::SpawnFromPath event("banana");
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_EQ("banana", event.FilePath());
+}
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, HoverToScene)
+{
+  events::HoverToScene event({1, 2, 3});
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_EQ(math::Vector3d(1, 2, 3), event.Point());
+}
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, LeftClickToScene)
+{
+  events::LeftClickToScene event({1, 2, 3});
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_EQ(math::Vector3d(1, 2, 3), event.Point());
+}
+


### PR DESCRIPTION
* Address codechecker warnings
* Added tests
* Pass and return `const &`
* Changed the snap API to `Position` / `Rotation` / `Scale`, to better match APIs of other Ignition libraries, like math, rendering, common...
* I think the "preview" concept is very specific to Gazebo and its server-client architecture. Other applications may be interested in using this event to just spawn anything into a scene. I think we'll only really know once we start making use of that event in `Scene3D`.


