### PR TITLE
Change deprecated Qt::MidButton

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -73,7 +73,7 @@ ignition::common::MouseEvent ignition::gui::convert(const QMouseEvent &_e)
     event.SetButton(common::MouseEvent::LEFT);
   else if (_e.button() == Qt::RightButton)
     event.SetButton(common::MouseEvent::RIGHT);
-  else if (_e.button() == Qt::MidButton)
+  else if (_e.button() == Qt::MiddleButton)
     event.SetButton(common::MouseEvent::MIDDLE);
 
   // Buttons
@@ -83,7 +83,7 @@ ignition::common::MouseEvent ignition::gui::convert(const QMouseEvent &_e)
   if (_e.buttons() & Qt::RightButton)
     event.SetButtons(event.Buttons() | common::MouseEvent::RIGHT);
 
-  if (_e.buttons() & Qt::MidButton)
+  if (_e.buttons() & Qt::MiddleButton)
     event.SetButtons(event.Buttons() | common::MouseEvent::MIDDLE);
 
   // Type


### PR DESCRIPTION
I noticed some new warnings on macOS:

https://build.osrfoundation.org/job/ignition_gui-ci-pr_any-homebrew-amd64/709/clang/new/

`'MidButton' is deprecated: MidButton is deprecated. Use MiddleButton instead`

This is probably only showing on macOS because it uses a newer version of Qt.

In any case `Qt::MiddleButton` has been an alias for `Qt::MidButton` for a long time, [since at least Qt4](https://doc.qt.io/archives/qt-4.8/qt.html), so this should be a safe change on all platforms.