### PR TITLE
Generate valid topics depending on world name

### DIFF
--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -124,6 +124,14 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
     this->dataPtr->controlService = "/world/" + worldName + "/control";
   }
+  this->dataPtr->controlService = transport::TopicUtils::AsValidTopic(
+      this->dataPtr->controlService);
+
+  if (this->dataPtr->controlService.empty())
+  {
+    ignerr << "Failed to create valid control service for world [" << worldName
+           << "]" << std::endl;
+  }
 
   ignmsg << "Using world control service [" << this->dataPtr->controlService
          << "]" << std::endl;
@@ -185,6 +193,7 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     statsTopic = "/world/" + worldName + "/stats";
   }
 
+  statsTopic = transport::TopicUtils::AsValidTopic(statsTopic);
   if (!statsTopic.empty())
   {
     // Subscribe to world_stats
@@ -197,6 +206,11 @@ void WorldControl::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     {
       ignmsg << "Listening to stats on [" << statsTopic << "]" << std::endl;
     }
+  }
+  else
+  {
+    ignerr << "Failed to create valid topic for world [" << worldName << "]"
+           << std::endl;
   }
 }
 

--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -127,6 +127,14 @@ void WorldStats::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     topic = "/world/" + worldName + "/stats";
   }
 
+  topic = transport::TopicUtils::AsValidTopic(topic);
+  if (topic.empty())
+  {
+    ignerr << "Failed to create valid topic for world [" << worldName << "]"
+           << std::endl;
+    return;
+  }
+
   if (!this->dataPtr->node.Subscribe(topic, &WorldStats::OnWorldStatsMsg,
       this))
   {


### PR DESCRIPTION
Redo of #163 targeting Dome.

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/239 is making sure that all topics can handle entity names with spaces. This can be the case for the world.

This makes use of the `AsValidTopic` function to convert world names to valid ones whenever possible.
