### PR TITLE
use default value of double ptr

### DIFF
--- a/src/ign.cc
+++ b/src/ign.cc
@@ -28,7 +28,7 @@
 #include "ignition/gui/MainWindow.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char **g_argv;
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE char *ignitionVersion()


### PR DESCRIPTION
this fix allows QApplication to properly instantiate on qt-5.15

resolves #162 

Seems like QT doesn't like the default value we are passing to QApplication constructor. This PR just uses the default **char value to be passed in.