### PR TITLE
Make Grid3D plugin more flexible

### DIFF
--- a/examples/config/scene3d.config
+++ b/examples/config/scene3d.config
@@ -17,6 +17,10 @@
     <background_color>0.8 0.8 0.8</background_color>
     <camera_pose>-6 0 6 0 0.5 0</camera_pose>
 </plugin>
+<plugin filename="Grid3D" name="3D Grid">
+  <engine>ogre</engine>
+  <scene>scene</scene>
+</plugin>
 <!-- TODO(anyone) Support multiple scenes in the same window
   plugin filename="Scene3D">
     <title>View 2</title>

--- a/src/plugins/grid_3d/Grid3D.hh
+++ b/src/plugins/grid_3d/Grid3D.hh
@@ -40,9 +40,9 @@ namespace plugins
   ///
   /// ## Configuration
   ///
-  /// * \<engine\> : Optional render engine name, defaults to 'ogre'.
-  /// * \<scene\> : Optional scene name, defaults to 'scene'. If a scene with
-  ///               the given name doesn't exist, the plugin is not initialized.
+  /// * \<engine\> : Optional render engine name, defaults to the first loaded
+  ///                engine.
+  /// * \<scene\> : Optional scene name, defaults to the first loaded scene.
   /// * \<auto_close\> : Set to true so the plugin closes after grids given by
   ///                    \<insert\> tags are added to the scene.
   /// * \<insert\> : One grid will be inserted at startup for each \<insert\>


### PR DESCRIPTION
This fixes https://github.com/ignitionrobotics/ign-gazebo/issues/312.

Trying to load `ogre` when `ogre2` is already loaded explodes the whole application. With this change, when loading the plugin from the menu, it now defaults to the first loaded engine / scene instead `ogre`.