### PR TITLE
Visualize single channel 8 bit image data

### DIFF
--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -345,6 +345,8 @@ void ImageDisplay::UpdateFromLInt16()
 /////////////////////////////////////////////////
 void ImageDisplay::UpdateFromLInt8()
 {
+  // todo(anyone) the code in this function is very similar to
+  // UpdateFromInt16 and UpdateFromFloat32. Consider merging these functions.
   unsigned int height = this->dataPtr->imageMsg.height();
   unsigned int width = this->dataPtr->imageMsg.width();
   QImage::Format qFormat = QImage::Format_RGB888;

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -160,6 +160,9 @@ void ImageDisplay::ProcessImage()
     case msgs::PixelFormatType::L_INT16:
       this->UpdateFromLInt16();
       break;
+    case msgs::PixelFormatType::L_INT8:
+      this->UpdateFromLInt8();
+      break;
     default:
     {
       ignwarn << "Unsupported image type: "
@@ -325,6 +328,60 @@ void ImageDisplay::UpdateFromLInt16()
     for (unsigned int i = 0; i < width; ++i)
     {
       uint16_t temp = buffer[idx++];
+      double t = static_cast<double>(temp-min) / range;
+      int r = 255*t;
+      int g = r;
+      int b = r;
+      QRgb value = qRgb(r, g, b);
+      image.setPixel(i, j, value);
+    }
+  }
+  this->dataPtr->provider->SetImage(image);
+  this->newImage();
+
+  delete[] buffer;
+}
+
+/////////////////////////////////////////////////
+void ImageDisplay::UpdateFromLInt8()
+{
+  unsigned int height = this->dataPtr->imageMsg.height();
+  unsigned int width = this->dataPtr->imageMsg.width();
+  QImage::Format qFormat = QImage::Format_RGB888;
+
+  QImage image = QImage(width, height, qFormat);
+
+  unsigned int samples = width * height;
+  unsigned char type;
+  // cppchecker recommends using sizeof(varname)
+  unsigned int bufferSize = samples * sizeof(type);
+
+  unsigned char *buffer = new unsigned char[samples];
+  memcpy(buffer, this->dataPtr->imageMsg.data().c_str(),
+      bufferSize);
+
+  // get min and max of temperature values
+  unsigned int min = 255;
+  unsigned int max = 0;
+  for (unsigned int i = 0; i < samples; ++i)
+  {
+    unsigned int temp = static_cast<unsigned int>(buffer[i]);
+    if (temp > max)
+      max = temp;
+    if (temp < min)
+      min = temp;
+  }
+
+  // convert temperature to grayscale image
+  double range = static_cast<double>(max - min);
+  if (ignition::math::equal(range, 0.0))
+    range = 1.0;
+  unsigned int idx = 0;
+  for (unsigned int j = 0; j < height; ++j)
+  {
+    for (unsigned int i = 0; i < width; ++i)
+    {
+      unsigned int temp = static_cast<unsigned int>(buffer[idx++]);
       double t = static_cast<double>(temp-min) / range;
       int r = 255*t;
       int g = r;

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -99,6 +99,9 @@ namespace plugins
     /// \brief Update from L_INT16
     private: void UpdateFromLInt16();
 
+    /// \brief Update from L_IN8T
+    private: void UpdateFromLInt8();
+
     /// \brief Subscriber callback when new image is received
     /// \param[in] _msg New image
     private: void OnImageMsg(const ignition::msgs::Image &_msg);


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

## Summary

Extended Image Display plugin to support visualizing single channel 8 bit unsigned integer data in a similar way to the 16 bit data. This is used by https://github.com/ignitionrobotics/ign-gazebo/pull/614 to visualize 8 bit thermal image data (see PR for screenshot)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge**

