### PR TITLE
👩‍🌾 Disable tests that initialize App on macOS: they're all flaky

### DIFF
--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -171,7 +171,8 @@ TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadDefaultConfig))
 }
 
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(InitializeMainWindow))
+TEST(ApplicationTest,
+    IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(InitializeMainWindow))
 {
   ignition::common::Console::SetVerbosity(4);
 

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -34,7 +34,7 @@ using namespace gui;
 
 // See https://github.com/ignitionrobotics/ign-gui/issues/75
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Constructor))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Constructor))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -60,7 +60,7 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Constructor))
 }
 
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugin))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadPlugin))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -118,7 +118,7 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugin))
 }
 
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadConfig))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadConfig))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -146,7 +146,7 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadConfig))
 }
 
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadDefaultConfig))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadDefaultConfig))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -171,7 +171,7 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadDefaultConfig))
 }
 
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(InitializeMainWindow))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(InitializeMainWindow))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -241,7 +241,7 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(InitializeMainWindow))
 }
 
 //////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Dialog))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Dialog))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -316,7 +316,7 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Dialog))
 }
 
 /////////////////////////////////////////////////
-TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(messageHandler))
+TEST(ApplicationTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(messageHandler))
 {
   ignition::common::Console::SetVerbosity(4);
 

--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -35,7 +35,7 @@ using namespace gui;
 
 /////////////////////////////////////////////////
 // See https://github.com/ignitionrobotics/ign-gui/issues/75
-TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Constructor))
+TEST(MainWindowTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Constructor))
 {
   ignition::common::Console::SetVerbosity(4);
   Application app(g_argc, g_argv);
@@ -48,7 +48,7 @@ TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Constructor))
 }
 
 /////////////////////////////////////////////////
-TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OnSaveConfig))
+TEST(MainWindowTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(OnSaveConfig))
 {
   ignition::common::Console::SetVerbosity(4);
   Application app(g_argc, g_argv);
@@ -85,7 +85,7 @@ TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OnSaveConfig))
 }
 
 /////////////////////////////////////////////////
-TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SaveConfigAs))
+TEST(MainWindowTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(SaveConfigAs))
 {
   ignition::common::Console::SetVerbosity(4);
   Application app(g_argc, g_argv);
@@ -121,7 +121,7 @@ TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SaveConfigAs))
 }
 
 /////////////////////////////////////////////////
-TEST(MainWindowTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(OnLoadConfig))
+TEST(MainWindowTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(OnLoadConfig))
 {
   ignition::common::Console::SetVerbosity(4);
   Application app(g_argc, g_argv);

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -32,7 +32,7 @@ using namespace ignition;
 using namespace gui;
 
 // See https://github.com/ignitionrobotics/ign-gui/issues/75
-TEST(PluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DeleteLater))
+TEST(PluginTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(DeleteLater))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -71,7 +71,7 @@ TEST(PluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(DeleteLater))
 }
 
 /////////////////////////////////////////////////
-TEST(PluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(InvalidXmlText))
+TEST(PluginTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(InvalidXmlText))
 {
   ignition::common::Console::SetVerbosity(4);
 
@@ -101,7 +101,7 @@ TEST(PluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(InvalidXmlText))
 }
 
 /////////////////////////////////////////////////
-TEST(PluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Getters))
+TEST(PluginTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Getters))
 {
   ignition::common::Console::SetVerbosity(4);
 


### PR DESCRIPTION
Signed-off-by: Louise Poubel <louise@openrobotics.org>

# 🦟 Bug workaround

See #123

## Summary

All the tests that initialize an `App` have been flaky on `ign-gui4` even though they consistently pass on `ign-gui3` (#123). I've tried a few different things to debug this with no luck.

Since we're not likely to have time to address these issues soon, I'm going to disable those tests so we don't pollute CI results with tests that are known to flake.

Our macOS CI uses a higher version of Qt than our Linux CI. So problems on macOS often let us know of upcoming problems on Linux. So commenting out these tests could just be pushing the problem down the road.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests - more like removed :smile: 
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [ ] ~~`codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))~~
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

---

https://github.com/osrf/buildfarmer/issues/156