### PR TITLE
Scene3D: port mesh material fixes from ign-gazebo

### DIFF
--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -631,7 +631,7 @@ rendering::VisualPtr SceneManager::LoadVisual(const msgs::Visual &_msg)
           double productAlpha = (1.0-_msg.transparency()) *
               (1.0 - submeshMat->Transparency());
           submeshMat->SetTransparency(1 - productAlpha);
-          submeshMat->SetCastShadows(_msg.transparency());
+          submeshMat->SetCastShadows(_msg.cast_shadows());
         }
       }
     }
@@ -642,7 +642,7 @@ rendering::VisualPtr SceneManager::LoadVisual(const msgs::Visual &_msg)
       material->SetTransparency(_msg.transparency());
 
       // cast shadows
-      material->SetCastShadows(_msg.transparency());
+      material->SetCastShadows(_msg.cast_shadows());
 
       geom->SetMaterial(material);
       // todo(anyone) SetMaterial function clones the input material.

--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -603,11 +603,7 @@ rendering::VisualPtr SceneManager::LoadVisual(const msgs::Visual &_msg)
     // Don't set a default material for meshes because they
     // may have their own
     // TODO(anyone) support overriding mesh material
-    else if (_msg.geometry().has_mesh())
-    {
-      material = geom->Material();
-    }
-    else
+    else if (!_msg.geometry().has_mesh())
     {
       // create default material
       material = this->scene->Material("ign-grey");
@@ -621,15 +617,40 @@ rendering::VisualPtr SceneManager::LoadVisual(const msgs::Visual &_msg)
         material->SetMetalness(1.0f);
       }
     }
+    else
+    {
+      // meshes created by mesh loader may have their own materials
+      // update/override their properties based on input sdf element values
+      auto mesh = std::dynamic_pointer_cast<rendering::Mesh>(geom);
+      for (unsigned int i = 0; i < mesh->SubMeshCount(); ++i)
+      {
+        auto submesh = mesh->SubMeshByIndex(i);
+        auto submeshMat = submesh->Material();
+        if (submeshMat)
+        {
+          double productAlpha = (1.0-_msg.transparency()) *
+              (1.0 - submeshMat->Transparency());
+          submeshMat->SetTransparency(1 - productAlpha);
+          submeshMat->SetCastShadows(_msg.transparency());
+        }
+      }
+    }
 
-    material->SetTransparency(_msg.transparency());
+    if (material)
+    {
+      // set transparency
+      material->SetTransparency(_msg.transparency());
 
-    // TODO(anyone) Get roughness and metalness from message instead
-    // of giving a default value.
-    material->SetRoughness(0.3f);
-    material->SetMetalness(0.3f);
+      // cast shadows
+      material->SetCastShadows(_msg.transparency());
 
-    geom->SetMaterial(material);
+      geom->SetMaterial(material);
+      // todo(anyone) SetMaterial function clones the input material.
+      // but does not take ownership of it so we need to destroy it here.
+      // This is not ideal. We should let ign-rendering handle the lifetime
+      // of this material
+      this->scene->DestroyMaterial(material);
+    }
   }
   else
   {


### PR DESCRIPTION
# 🦟 Bug fix

Port fixes for material loading in the Scene3D plugin from ign-gazebo.

## Summary

As noted in #137, the Scene3D plugin was forked for use in ign-gazebo, with the intention of consolidating back with the ign-gui plugin to reduce duplication. This ports some fixes for mesh material loading to ign-gui made in ignitionrobotics/ign-gazebo@897ef65 as part of [bitbucket PR 315](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-gazebo/pull-requests/315/page/1) as well as some other fixes to more closely match the [current code in ign-gazebo's SceneManager](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo4_4.6.0/src/rendering/SceneManager.cc#L300-L356).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**