### PR TITLE
Bump to 3.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui3 VERSION 3.5.0)
+project(ignition-gui3 VERSION 3.5.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 ### Ignition Gui 3.X.X (202X-XX-XX)
 
+### Ignition Gui 3.5.1 (2021-03-17)
+
+1. Scene3D: port mesh material fixes from ign-gazebo
+    * [Pull request #191](https://github.com/ignitionrobotics/ign-gui/pull/191)
+
 ### Ignition Gui 3.5.0 (2021-03-10)
 
 1. Screenshot plugin

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 1. Scene3D: port mesh material fixes from ign-gazebo
     * [Pull request #191](https://github.com/ignitionrobotics/ign-gui/pull/191)
 
+1. Improve the height of plugins in the right split
+    * [Pull request #194](https://github.com/ignitionrobotics/ign-gui/pull/194)
+
 ### Ignition Gui 3.5.0 (2021-03-10)
 
 1. Screenshot plugin

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ### Ignition Gui 3.X.X (202X-XX-XX)
 
-### Ignition Gui 3.5.1 (2021-03-17)
+### Ignition Gui 3.5.1 (2021-03-18)
 
 1. Scene3D: port mesh material fixes from ign-gazebo
     * [Pull request #191](https://github.com/ignitionrobotics/ign-gui/pull/191)


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.5.1 release.

Comparison to 3.5.0: https://github.com/ignitionrobotics/ign-gui/compare/ignition-gui3_3.5.0...ign-gui3

The changes in #191 are needed by TRI Roads project. @chapulina do we need to wait for #194?

## Checklist
- [ ] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge**
