### PR TITLE
check_test_ran.py: remove grep/xsltproc

### DIFF
--- a/tools/check_test_ran.py
+++ b/tools/check_test_ran.py
@@ -44,7 +44,6 @@ NAME="check_test_ran.py"
 
 import os
 import sys
-import subprocess
 
 def usage():
     print("""Usage:
@@ -52,29 +51,6 @@ def usage():
 """%(NAME), file=sys.stderr)
     print(sys.argv)
     sys.exit(getattr(os, 'EX_USAGE', 1))
-
-def run_grep(filename, arg):
-    process = subprocess.Popen(['grep', arg, filename], stdout=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    return stdout, stderr
-
-def run_xsltproc(stylesheet, document):
-    try:
-        process = subprocess.Popen(['xsltproc', stylesheet, document], stdout=subprocess.PIPE)
-        stdout, stderr = process.communicate()
-        # Overwrite same document
-        open(document, 'w').write(stdout)
-    except OSError as err:
-        test_name = os.path.basename(document)
-        f = open(document, 'w')
-        d = {'test': test_name, 'test_file': document, 'test_no_xml': test_name.replace('.xml', '')}
-        f.write("""<?xml version="1.0" encoding="UTF-8"?>
-<testsuite tests="1" failures="1" time="1" errors="0" name="%(test)s">
-  <testcase name="test_ran" status="run" time="1" classname="%(test_no_xml)s">
-    <failure message="Unable to find xsltproc. Can not parse output test for QTest suite." type=""/>
-  </testcase>
-</testsuite>"""%d)
-        sys.exit(getattr(os, 'EX_USAGE', 1))
 
 def check_main():
     if len(sys.argv) < 2:
@@ -98,14 +74,6 @@ def check_main():
     <failure message="Unable to find test results for %(test)s, test did not run.\nExpected results in %(test_file)s" type=""/>
   </testcase>
 </testsuite>"""%d)
-        sys.exit(getattr(os, 'EX_USAGE', 1))
-
-    # Checking if test is a QTest file
-    stdout, stderr = run_grep(test_file, "QtVersion")
-    if (stdout):
-        print("Detect QTest xml file. Converting to JUNIT ...")
-        stylesheet = os.path.dirname(os.path.abspath(__file__)) + "/qtest_to_junit.xslt"
-        run_xsltproc(stylesheet, test_file)
 
 if __name__ == '__main__':
     check_main()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #198 

## Summary

We aren't using QTest anymore in ign-gui, so remove
the parts of check_test_ran.py that translated QTest
xml files into junit, since they don't work easily
on Windows and aren't needed any longer.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
