### PR TITLE
Edifice tutorial updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,22 +70,10 @@ where the YAML file for the package is found, such as
 export IGN_CONFIG_PATH=/usr/local/share/ignition
 ```
 
-However, that environment variable only takes a single path, which means if the
-installations from source are in different locations, only one can be specified.
-
-Another workaround for working with multiple Ignition libraries on the command
-line is using symbolic links to each library's YAML file.
+Multiple paths can be specified using the `:` delimiter. For example,
 ```
-mkdir ~/.ignition/tools/configs -p
-cd ~/.ignition/tools/configs/
-ln -s /usr/local/share/ignition/fuel6.yaml .
-ln -s /usr/local/share/ignition/transport10.yaml .
-ln -s /usr/local/share/ignition/transportlog10.yaml .
-...
-export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
+export IGN_CONFIG_PATH=/user/local/share/ignition/:/path/to/some/other/location
 ```
-
-This issue is tracked [here](https://github.com/ignitionrobotics/ign-tools/issues/8).
 
 # Folder Structure
 
@@ -107,9 +95,9 @@ This issue is tracked [here](https://github.com/ignitionrobotics/ign-tools/issue
   `ign gui -c <path to file>`
 
 * `examples/plugin`: Example plugins which can be compiled and loaded as explained
-  in [this tutorial](https://ignitionrobotics.org/api/gui/1.0/plugins.html).
+  in [this tutorial](https://ignitionrobotics.org/api/gui/5.0/plugins.html).
 
-* `tutorials`: Markdown files for the [tutorials](https://ignitionrobotics.org/api/gui/1.0/tutorials.html).
+* `tutorials`: Markdown files for the [tutorials](https://ignitionrobotics.org/api/gui/5.0/tutorials.html).
 
 * `conf`: Files needed by [ign-tools](https://github.com/ignitionrobotics/ign-tools).
 

--- a/examples/config/layout.config
+++ b/examples/config/layout.config
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 
 <window>
-  <position_x>873</position_x>
-  <position_y>230</position_y>
   <width>550</width>
   <height>551</height>
 </window>

--- a/examples/config/scene3d.config
+++ b/examples/config/scene3d.config
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 
 <window>
-    <position_x>815</position_x>
-    <position_y>341</position_y>
     <width>1216</width>
     <height>894</height>
 </window>

--- a/tutorials/03_plugins.md
+++ b/tutorials/03_plugins.md
@@ -8,9 +8,9 @@ Previous Tutorial: \ref commandline
 An Ignition GUI plugin is a shared library that defines a widget.
 The plugin contains [QML](https://doc.qt.io/qt-5/qtqml-index.html)
 code that specifies what the widget looks like, as well as C++ code
-that defines the plugin's behaviour and ties it to other libraries.
+that defines the plugin's behavior and ties it to other libraries.
 
-See [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui3/examples/plugin/hello_plugin/)
+See [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/examples/plugin/hello_plugin/)
 for an example.
 
 ## Finding plugins
@@ -20,7 +20,7 @@ Ignition GUI will look for plugins on the following paths, in this order:
 1. All paths set on the `IGN_GUI_PLUGIN_PATH` environment variable
 2. All paths added by calling `ignition::gui::addPluginPath`
 3. `~/.ignition/gui/plugins`
-4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/3.3/namespaceignition_1_1gui_1_1plugins.html)
+4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/5.0/namespaceignition_1_1gui_1_1plugins.html)
 
 ## Configuring plugins
 

--- a/tutorials/04_layout.md
+++ b/tutorials/04_layout.md
@@ -8,13 +8,8 @@ Previous Tutorial: \ref plugins
 It's possible to define the layout of various plugins loaded to the main window
 by adding a `<window>` element to the config file. The child elements are:
 
-* `<position_x>`: Horizontal position of window's top-left corner in pixels.
-* `<position_y>`: Vertical position of window's top-left corner in pixels.
 * `<width>`: Window's width in pixels
 * `<height>`: Window's height in pixels
-* `<state>`: The state of the window's docks and tabs, described as a Base64
-             encoded `QByteArray`. More information
-             [here](http://doc.qt.io/qt-5/qmainwindow.html#saveState).
 * `<menus>`: Configure menu options
     * `<drawer>`: Side drawer configuration.
         * `visible`: Set to false to hide the drawer and the button to trigger it.

--- a/tutorials/04_layout.md
+++ b/tutorials/04_layout.md
@@ -8,14 +8,14 @@ Previous Tutorial: \ref plugins
 It's possible to define the layout of various plugins loaded to the main window
 by adding a `<window>` element to the config file. The child elements are:
 
-* `<position_x>`: **v0** Horizontal position of window's top-left corner in pixels.
-* `<position_y>`: **v0** Vertical position of window's top-left corner in pixels.
+* `<position_x>`: Horizontal position of window's top-left corner in pixels.
+* `<position_y>`: Vertical position of window's top-left corner in pixels.
 * `<width>`: Window's width in pixels
 * `<height>`: Window's height in pixels
-* `<state>`: **v0** The state of the widow's docks and tabs, described as a Base64
+* `<state>`: The state of the window's docks and tabs, described as a Base64
              encoded `QByteArray`. More information
              [here](http://doc.qt.io/qt-5/qmainwindow.html#saveState).
-* `<menus>`: **v0** Configure menu options
+* `<menus>`: Configure menu options
     * `<drawer>`: Side drawer configuration.
         * `visible`: Set to false to hide the drawer and the button to trigger it.
     * `<plugins>`: Plugins menu configuration.

--- a/tutorials/05_style.md
+++ b/tutorials/05_style.md
@@ -12,7 +12,7 @@ but it is also possible to use others such as Default and Universal. This tutori
 focuses on customizing the Material style.
 
 The default style is hardcoded into the
-[qtquickcontrols2.conf](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui4/include/ignition/gui/qtquickcontrols2.conf)
+[qtquickcontrols2.conf](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/include/ignition/gui/qtquickcontrols2.conf)
 file.
 
 There are a few ways to override the default style:
@@ -21,7 +21,7 @@ There are a few ways to override the default style:
 * Setting environment variables (env)
 * Through Ignition GUI config files (config)
 
-If styles are set from multiple sources, this is the order in which they take precendence:
+If styles are set from multiple sources, this is the order in which they take precedence:
 
 **GUI > config > env**
 
@@ -45,7 +45,7 @@ On top of those, Ignition GUI also offers a few variables specific to customizin
 the top toolbar.
 
 By default, the top toolbar will use the primary color, while the plugin toolbars will
-use the accent color, according to the current theme. Users can override this behaviour
+use the accent color, according to the current theme. Users can override this behavior
 and decouple the toolbar colors from the rest of the controls with the following
 variables:
 

--- a/tutorials/07_config.md
+++ b/tutorials/07_config.md
@@ -20,7 +20,7 @@ From the command line, use the `--config` / `-c` option, for example:
 `ign gui -c path/to/example.config`
 
 From the C++ API, pass the file path to
-[Application::LoadConfig](https://ignitionrobotics.org/api/gui/3.0/classignition_1_1gui_1_1Application.html#a03c4c3a1b1e58cc4bff05658f21fff17).
+[Application::LoadConfig](https://ignitionrobotics.org/api/gui/5.0/classignition_1_1gui_1_1Application.html#a03c4c3a1b1e58cc4bff05658f21fff17).
 
 ### File structure
 
@@ -32,12 +32,12 @@ Ignition GUI accepts the following top-level elements on a config file:
     * `filename`: This attribute specifies the plugin library to be loaded.
     * `<ignition-gui>`: Ignition GUI processes this block before passing the
       config to the plugin. See
-      [plugin_params.config](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui2/examples/config/plugin_params.config)
+      [plugin_params.config](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/examples/config/plugin_params.config)
       for an example.
     * custom elements: Developers can read custom plugin configurations overriding the
-      [Plugin::LoadConfig](https://ignitionrobotics.org/api/gui/3.0/classignition_1_1gui_1_1Plugin.html#a72064530af4cd247b994b905559fd4ee)
+      [Plugin::LoadConfig](https://ignitionrobotics.org/api/gui/5.0/classignition_1_1gui_1_1Plugin.html#a72064530af4cd247b994b905559fd4ee)
       function, see the
-      [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui2/examples/plugin/hello_plugin/HelloPlugin.cc)
+      [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/examples/plugin/hello_plugin/HelloPlugin.cc)
       example.
 
 See the example plugin block below:
@@ -52,4 +52,3 @@ See the example plugin block below:
 This will load the `libImageDisplay.so` plugin, Ignition GUI will set its
 `height` to `120` pixels, and the plugin-specific `<topic>` parameter will be
 handled within `ImageDisplay::LoadConfig`.
-


### PR DESCRIPTION
## Summary

- Removed workaround in `README` for multiple paths and made note about `:` delimiter since https://github.com/ignitionrobotics/ign-tools/issues/8 is closed
- Updated version links
  - Some links will be broken until `ign-gui5` branch is created (e.g., In `03_plugins.md`, the link to `HelloPlugin`)
- Spelling fixes
- Removed `<window>` elements from `04_layout.md` that do not work: 80cc15dce6fab705aef5e61124f7901caa134cfa

## Checklist
- [x] Signed all commits for DCO
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**