### PR TITLE
Bump main to 6.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui5 VERSION 5.0.0)
+project(ignition-gui6 VERSION 6.0.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 2.3 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX pre2)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Ignition Gui 6
+
+### Ignition Gui 6.X.X
+
+### Ignition Gui 6.0.0 (20XX-XX-XX)
+
 ## Ignition Gui 5
 
 ### Ignition Gui 5.X.X

--- a/examples/plugin/custom_context_menu/CMakeLists.txt
+++ b/examples/plugin/custom_context_menu/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 find_package(ignition-common4 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/dialog_from_plugin/CMakeLists.txt
+++ b/examples/plugin/dialog_from_plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 find_package(ignition-common4 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/hello_plugin/CMakeLists.txt
+++ b/examples/plugin/hello_plugin/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 find_package(ignition-common4 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/ign_components/CMakeLists.txt
+++ b/examples/plugin/ign_components/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package (Qt5
   REQUIRED
 )
 
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 find_package(ignition-common4 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/plugin/multiple_qml/CMakeLists.txt
+++ b/examples/plugin/multiple_qml/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 find_package(ignition-common4 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")

--- a/examples/standalone/custom_drawer/CMakeLists.txt
+++ b/examples/standalone/custom_drawer/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 
 QT5_ADD_RESOURCES(resources_RCC custom_drawer.qrc)
 

--- a/examples/standalone/dialogs/CMakeLists.txt
+++ b/examples/standalone/dialogs/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")
 

--- a/examples/standalone/window/CMakeLists.txt
+++ b/examples/standalone/window/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package (Qt5
 )
 
 # Find the Ignition gui library
-find_package(ignition-gui5 REQUIRED)
+find_package(ignition-gui6 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS}")
 

--- a/tutorials/03_plugins.md
+++ b/tutorials/03_plugins.md
@@ -10,7 +10,7 @@ The plugin contains [QML](https://doc.qt.io/qt-5/qtqml-index.html)
 code that specifies what the widget looks like, as well as C++ code
 that defines the plugin's behavior and ties it to other libraries.
 
-See [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/examples/plugin/hello_plugin/)
+See [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/main/examples/plugin/hello_plugin/)
 for an example.
 
 ## Finding plugins
@@ -20,7 +20,7 @@ Ignition GUI will look for plugins on the following paths, in this order:
 1. All paths set on the `IGN_GUI_PLUGIN_PATH` environment variable
 2. All paths added by calling `ignition::gui::addPluginPath`
 3. `~/.ignition/gui/plugins`
-4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/5.0/namespaceignition_1_1gui_1_1plugins.html)
+4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/6.0/namespaceignition_1_1gui_1_1plugins.html)
 
 ## Configuring plugins
 

--- a/tutorials/05_style.md
+++ b/tutorials/05_style.md
@@ -12,7 +12,7 @@ but it is also possible to use others such as Default and Universal. This tutori
 focuses on customizing the Material style.
 
 The default style is hardcoded into the
-[qtquickcontrols2.conf](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/include/ignition/gui/qtquickcontrols2.conf)
+[qtquickcontrols2.conf](https://github.com/ignitionrobotics/ign-gui/blob/main/include/ignition/gui/qtquickcontrols2.conf)
 file.
 
 There are a few ways to override the default style:

--- a/tutorials/07_config.md
+++ b/tutorials/07_config.md
@@ -20,7 +20,7 @@ From the command line, use the `--config` / `-c` option, for example:
 `ign gui -c path/to/example.config`
 
 From the C++ API, pass the file path to
-[Application::LoadConfig](https://ignitionrobotics.org/api/gui/5.0/classignition_1_1gui_1_1Application.html#a03c4c3a1b1e58cc4bff05658f21fff17).
+[Application::LoadConfig](https://ignitionrobotics.org/api/gui/6.0/classignition_1_1gui_1_1Application.html#a03c4c3a1b1e58cc4bff05658f21fff17).
 
 ### File structure
 
@@ -32,12 +32,12 @@ Ignition GUI accepts the following top-level elements on a config file:
     * `filename`: This attribute specifies the plugin library to be loaded.
     * `<ignition-gui>`: Ignition GUI processes this block before passing the
       config to the plugin. See
-      [plugin_params.config](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/examples/config/plugin_params.config)
+      [plugin_params.config](https://github.com/ignitionrobotics/ign-gui/blob/main/examples/config/plugin_params.config)
       for an example.
     * custom elements: Developers can read custom plugin configurations overriding the
-      [Plugin::LoadConfig](https://ignitionrobotics.org/api/gui/5.0/classignition_1_1gui_1_1Plugin.html#a72064530af4cd247b994b905559fd4ee)
+      [Plugin::LoadConfig](https://ignitionrobotics.org/api/gui/6.0/classignition_1_1gui_1_1Plugin.html#a720646.0af4cd247b994b905559fd4ee)
       function, see the
-      [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/ign-gui5/examples/plugin/hello_plugin/HelloPlugin.cc)
+      [HelloPlugin](https://github.com/ignitionrobotics/ign-gui/blob/main/examples/plugin/hello_plugin/HelloPlugin.cc)
       example.
 
 See the example plugin block below:


### PR DESCRIPTION
Branch `ign-gui5` has been created for the Edifice release and 5.0.0 released from that.

The `main` branch now corresponds to version 6.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421