### PR TITLE
Support Capsule and Ellipsoid in Scene3D

### DIFF
--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -29,6 +29,8 @@
 #include <ignition/plugin/Register.hh>
 #include <ignition/common/MeshManager.hh>
 
+#include <ignition/rendering/Capsule.hh>
+
 #include <ignition/math/Vector2.hh>
 #include <ignition/math/Vector3.hh>
 
@@ -680,6 +682,20 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const msgs::Geometry &_msg,
     scale.X() = _msg.cylinder().radius() * 2;
     scale.Y() = scale.X();
     scale.Z() = _msg.cylinder().length();
+  }
+  else if (_msg.has_capsule())
+  {
+    auto capsule = this->scene->CreateCapsule();
+    capsule->SetRadius(_msg.capsule().radius());
+    capsule->SetLength(_msg.capsule().length());
+    geom = capsule;
+  }
+  else if (_msg.has_ellipsoid())
+  {
+    geom = this->scene->CreateSphere();
+    scale.X() = _msg.ellipsoid().radii().x() * 2;
+    scale.Y() = _msg.ellipsoid().radii().y() * 2;
+    scale.Z() = _msg.ellipsoid().radii().z() * 2;
   }
   else if (_msg.has_plane())
   {


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🦟 Bug fix

## Summary

Capsule and ellipsoid are not handle in the Scene3D. These PR adds support for them

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**