### PR TITLE
Removed duplicated code with rendering::sceneFromFirstRenderEngine

### DIFF
--- a/src/plugins/screenshot/Screenshot.cc
+++ b/src/plugins/screenshot/Screenshot.cc
@@ -181,52 +181,8 @@ void Screenshot::FindUserCamera()
   if (nullptr != this->dataPtr->userCamera)
     return;
 
-  auto loadedEngNames = ignition::rendering::loadedEngines();
-  if (loadedEngNames.empty())
-  {
-    igndbg << "No rendering engine is loaded yet" << std::endl;
-    return;
-  }
-
-  // assume there is only one engine loaded
-  auto engineName = loadedEngNames[0];
-  if (loadedEngNames.size() > 1)
-  {
-    igndbg << "More than one engine is available. "
-      << "Using engine [" << engineName << "]" << std::endl;
-  }
-  auto engine = ignition::rendering::engine(engineName);
-  if (!engine)
-  {
-    ignerr << "Internal error: failed to load engine [" << engineName
-      << "]. Grid plugin won't work." << std::endl;
-    return;
-  }
-
-  if (engine->SceneCount() == 0)
-  {
-    igndbg << "No scene has been created yet" << std::endl;
-    return;
-  }
-
   // Get first scene
-  auto scene = engine->SceneByIndex(0);
-  if (nullptr == scene)
-  {
-    ignerr << "Internal error: scene is null." << std::endl;
-    return;
-  }
-
-  if (engine->SceneCount() > 1)
-  {
-    igndbg << "More than one scene is available. "
-      << "Using scene [" << scene->Name() << "]" << std::endl;
-  }
-
-  if (!scene->IsInitialized() || nullptr == scene->RootVisual())
-  {
-    return;
-  }
+  auto scene = rendering::sceneFromFirstRenderEngine();
 
   for (unsigned int i = 0; i < scene->NodeCount(); ++i)
   {


### PR DESCRIPTION
# Enhancement
## Summary
Related to this PR in ignition-renderin https://github.com/ignitionrobotics/ign-rendering/pull/320#event-4749407284. It uses the helper function rendering::sceneFromFirstRenderEngine to get the first scene that can be found in any rendering engine.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
