### PR TITLE
Confirmation dialog when closing main window

### DIFF
--- a/examples/config/layout.config
+++ b/examples/config/layout.config
@@ -6,6 +6,7 @@
   <position_y>230</position_y>
   <width>550</width>
   <height>551</height>
+  <dialog_on_exit>true</dialog_on_exit>
 </window>
 <plugin filename="Publisher">
     <title>1</title>

--- a/include/ignition/gui/MainWindow.hh
+++ b/include/ignition/gui/MainWindow.hh
@@ -44,7 +44,7 @@ namespace ignition
 
     /// \brief The main window class creates a QQuickWindow and acts as an
     /// interface which provides properties and functions which can be called
-    /// from MainWindow.qml
+    /// from Main.qml
     class IGNITION_GUI_VISIBLE MainWindow : public QObject
     {
       Q_OBJECT
@@ -175,6 +175,14 @@ namespace ignition
         READ ShowPluginMenu
         WRITE SetShowPluginMenu
         NOTIFY ShowPluginMenuChanged
+      )
+
+      /// \brief Flag to enable confirmation dialog on exit
+      Q_PROPERTY(
+        bool showDialogOnExit
+        READ ShowDialogOnExit
+        WRITE SetShowDialogOnExit
+        NOTIFY ShowDialogOnExitChanged
       )
 
       /// \brief Constructor
@@ -344,6 +352,14 @@ namespace ignition
       /// \param[in] _showPluginMenu True to show.
       public: Q_INVOKABLE void SetShowPluginMenu(const bool _showPluginMenu);
 
+      /// \brief Get the flag to show the plugin menu.
+      /// \return True to show.
+      public: Q_INVOKABLE bool ShowDialogOnExit() const;
+
+      /// \brief Set the flag to show the confirmation dialog when exiting.
+      /// \param[in] _showDialogOnExit True to show.
+      public: Q_INVOKABLE void SetShowDialogOnExit(bool _showDialogOnExit);
+
       /// \brief Callback when load configuration is selected
       public slots: void OnLoadConfig(const QString &_path);
 
@@ -397,6 +413,9 @@ namespace ignition
 
       /// \brief Notifies when the show menu flag has changed.
       signals: void ShowPluginMenuChanged();
+
+      /// \brief Notifies when the showDialogOnExit flag has changed.
+      signals: void ShowDialogOnExitChanged();
 
       /// \brief Notifies when the window config has changed.
       signals: void configChanged();
@@ -483,6 +502,9 @@ namespace ignition
 
       /// \brief Show the plugins menu
       bool showPluginMenu{true};
+
+      /// \brief Show the confirmation dialog on exit
+      bool showDialogOnExit{false};
 
       /// \brief True if plugins found in plugin paths should be listed under
       /// the Plugins menu. True by default.

--- a/include/ignition/gui/MainWindow.hh
+++ b/include/ignition/gui/MainWindow.hh
@@ -503,9 +503,6 @@ namespace ignition
       /// \brief Show the plugins menu
       bool showPluginMenu{true};
 
-      /// \brief Show the confirmation dialog on exit
-      bool showDialogOnExit{false};
-
       /// \brief True if plugins found in plugin paths should be listed under
       /// the Plugins menu. True by default.
       bool pluginsFromPaths{true};

--- a/include/ignition/gui/qml/Main.qml
+++ b/include/ignition/gui/qml/Main.qml
@@ -45,7 +45,7 @@ ApplicationWindow
   property string pluginToolBarTextColorLight: MainWindow.pluginToolBarTextColorLight
   property string pluginToolBarColorDark: MainWindow.pluginToolBarColorDark
   property string pluginToolBarTextColorDark: MainWindow.pluginToolBarTextColorDark
-
+  property bool showDialogOnExit: MainWindow.showDialogOnExit
   /**
    * Tool bar background color
    */
@@ -73,8 +73,8 @@ ApplicationWindow
 
   // Handler for window closing
   onClosing: {
-    close.accepted = !MainWindow.showDialogOnExit
-    if(MainWindow.showDialogOnExit){
+    close.accepted = !showDialogOnExit
+    if(showDialogOnExit){
       confirmationDialogOnExit.open()
     }
   }

--- a/include/ignition/gui/qml/Main.qml
+++ b/include/ignition/gui/qml/Main.qml
@@ -71,6 +71,14 @@ ApplicationWindow
     titleLabel.text = window.title
   }
 
+  // Handler for window closing
+  onClosing: {
+    close.accepted = !MainWindow.showDialogOnExit
+    if(MainWindow.showDialogOnExit){
+      confirmationDialogOnExit.open()
+    }
+  }
+
   // C++ signals to QML slots
   Connections {
     target: MainWindow
@@ -313,6 +321,27 @@ ApplicationWindow
         wrapMode: Label.Wrap
         font.pixelSize: 18
       }
+    }
+  }
+
+  /**
+   *  Confirmation dialog on close button
+   */
+  Dialog {
+    id: confirmationDialogOnExit
+    title: "Do you really want to exit?"
+
+    modal: true
+    focus: true
+    parent: ApplicationWindow.overlay
+    width: 300
+    x: (parent.width - width) / 2
+    y: (parent.height - height) / 2
+    closePolicy: Popup.CloseOnEscape
+    standardButtons: Dialog.Ok | Dialog.Cancel
+
+    onAccepted: {
+      Qt.quit()
     }
   }
 }

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -275,6 +275,14 @@ bool Application::LoadConfig(const std::string &_config)
     this->dataPtr->windowConfig.MergeFromXML(std::string(printer.CStr()));
   }
 
+  // Closing behavior.
+  if (auto dialogOnExitElem = doc.FirstChildElement("dialog_on_exit"))
+  {
+    bool showDialogOnExit{false};
+    dialogOnExitElem->QueryBoolText(&showDialogOnExit);
+    this->dataPtr->mainWin->SetShowDialogOnExit(showDialogOnExit);
+  }
+
   this->ApplyConfig();
 
   return true;

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -273,14 +273,14 @@ bool Application::LoadConfig(const std::string &_config)
       return false;
     }
     this->dataPtr->windowConfig.MergeFromXML(std::string(printer.CStr()));
-  }
 
-  // Closing behavior.
-  if (auto dialogOnExitElem = doc.FirstChildElement("dialog_on_exit"))
-  {
-    bool showDialogOnExit{false};
-    dialogOnExitElem->QueryBoolText(&showDialogOnExit);
-    this->dataPtr->mainWin->SetShowDialogOnExit(showDialogOnExit);
+    // Closing behavior.
+    if (auto dialogOnExitElem = winElem->FirstChildElement("dialog_on_exit"))
+    {
+      bool showDialogOnExit{false};
+      dialogOnExitElem->QueryBoolText(&showDialogOnExit);
+      this->dataPtr->mainWin->SetShowDialogOnExit(showDialogOnExit);
+    }
   }
 
   this->ApplyConfig();

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -47,6 +47,9 @@ namespace ignition
       /// \brief Minimum number of paint events to consider the window to be
       /// fully initialized.
       public: const unsigned int paintCountMin{20};
+
+      /// \brief Show the confirmation dialog on exit
+      public: bool showDialogOnExit{false};
     };
   }
 }
@@ -259,12 +262,6 @@ bool MainWindow::ApplyConfig(const WindowConfig &_config)
   this->SetShowDefaultDrawerOpts(_config.showDefaultDrawerOpts);
   this->SetShowPluginMenu(_config.showPluginMenu);
 
-  // Confirmation dialog on exit
-  if (!_config.IsIgnoring("dialog_on_exit"))
-  {
-    this->SetShowDialogOnExit(_config.showDialogOnExit);
-  }
-
   // Keep a copy
   this->dataPtr->windowConfig = _config;
 
@@ -319,7 +316,6 @@ WindowConfig MainWindow::CurrentWindowConfig() const
   config.pluginsFromPaths = this->dataPtr->windowConfig.pluginsFromPaths;
   config.showPlugins = this->dataPtr->windowConfig.showPlugins;
   config.ignoredProps = this->dataPtr->windowConfig.ignoredProps;
-  config.showDialogOnExit = this->dataPtr->windowConfig.showDialogOnExit;
 
   // Plugins
   auto plugins = this->findChildren<Plugin *>();
@@ -477,12 +473,6 @@ bool WindowConfig::MergeFromXML(const std::string &_windowXml)
     }
   }
 
-  // Show dialog on exit
-  if (auto dialogOnExitElem = winElem->FirstChildElement("dialog_on_exit"))
-  {
-    dialogOnExitElem->QueryBoolText(&this->showDialogOnExit);
-  }
-
   // Ignore
   for (auto ignoreElem = winElem->FirstChildElement("ignore");
       ignoreElem != nullptr;
@@ -609,14 +599,6 @@ std::string WindowConfig::XMLString() const
     }
 
     windowElem->InsertEndChild(menusElem);
-  }
-
-  // Dialog on exit
-  if (!this->IsIgnoring("dialog_on_exit"))
-  {
-    auto elem = doc.NewElement("dialog_on_exit");
-    elem->SetText(this->showDialogOnExit ? "true" : "false");
-    windowElem->InsertEndChild(elem);
   }
 
   // Ignored properties
@@ -868,12 +850,12 @@ void MainWindow::SetShowPluginMenu(const bool _showPluginMenu)
 /////////////////////////////////////////////////
 bool MainWindow::ShowDialogOnExit() const
 {
-  return this->dataPtr->windowConfig.showDialogOnExit;
+  return this->dataPtr->showDialogOnExit;
 }
 
 /////////////////////////////////////////////////
 void MainWindow::SetShowDialogOnExit(bool _showDialogOnExit)
 {
-  this->dataPtr->windowConfig.showDialogOnExit = _showDialogOnExit;
+  this->dataPtr->showDialogOnExit = _showDialogOnExit;
   this->ShowDialogOnExitChanged();
 }

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -259,6 +259,12 @@ bool MainWindow::ApplyConfig(const WindowConfig &_config)
   this->SetShowDefaultDrawerOpts(_config.showDefaultDrawerOpts);
   this->SetShowPluginMenu(_config.showPluginMenu);
 
+  // Confirmation dialog on exit
+  if (!_config.IsIgnoring("dialog_on_exit"))
+  {
+    this->SetShowDialogOnExit(_config.showDialogOnExit);
+  }
+
   // Keep a copy
   this->dataPtr->windowConfig = _config;
 
@@ -313,6 +319,7 @@ WindowConfig MainWindow::CurrentWindowConfig() const
   config.pluginsFromPaths = this->dataPtr->windowConfig.pluginsFromPaths;
   config.showPlugins = this->dataPtr->windowConfig.showPlugins;
   config.ignoredProps = this->dataPtr->windowConfig.ignoredProps;
+  config.showDialogOnExit = this->dataPtr->windowConfig.showDialogOnExit;
 
   // Plugins
   auto plugins = this->findChildren<Plugin *>();
@@ -470,6 +477,12 @@ bool WindowConfig::MergeFromXML(const std::string &_windowXml)
     }
   }
 
+  // Show dialog on exit
+  if (auto dialogOnExitElem = winElem->FirstChildElement("dialog_on_exit"))
+  {
+    dialogOnExitElem->QueryBoolText(&this->showDialogOnExit);
+  }
+
   // Ignore
   for (auto ignoreElem = winElem->FirstChildElement("ignore");
       ignoreElem != nullptr;
@@ -596,6 +609,14 @@ std::string WindowConfig::XMLString() const
     }
 
     windowElem->InsertEndChild(menusElem);
+  }
+
+  // Dialog on exit
+  if (!this->IsIgnoring("dialog_on_exit"))
+  {
+    auto elem = doc.NewElement("dialog_on_exit");
+    elem->SetText(this->showDialogOnExit ? "true" : "false");
+    windowElem->InsertEndChild(elem);
   }
 
   // Ignored properties
@@ -842,4 +863,17 @@ void MainWindow::SetShowPluginMenu(const bool _showPluginMenu)
 {
   this->dataPtr->windowConfig.showPluginMenu = _showPluginMenu;
   this->ShowPluginMenuChanged();
+}
+
+/////////////////////////////////////////////////
+bool MainWindow::ShowDialogOnExit() const
+{
+  return this->dataPtr->windowConfig.showDialogOnExit;
+}
+
+/////////////////////////////////////////////////
+void MainWindow::SetShowDialogOnExit(bool _showDialogOnExit)
+{
+  this->dataPtr->windowConfig.showDialogOnExit = _showDialogOnExit;
+  this->ShowDialogOnExitChanged();
 }

--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -211,7 +211,6 @@ TEST(WindowConfigTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(defaultValues))
   EXPECT_TRUE(c.materialAccent.empty());
   EXPECT_TRUE(c.showDrawer);
   EXPECT_TRUE(c.showDefaultDrawerOpts);
-  EXPECT_FALSE(c.showDialogOnExit);
   EXPECT_TRUE(c.showPluginMenu);
   EXPECT_TRUE(c.pluginsFromPaths);
   EXPECT_TRUE(c.showPlugins.empty());
@@ -226,7 +225,6 @@ TEST(WindowConfigTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(defaultValues))
   EXPECT_NE(xml.find("<height>"), std::string::npos);
   EXPECT_NE(xml.find("<menus>"), std::string::npos);
   EXPECT_NE(xml.find("<drawer"), std::string::npos);
-  EXPECT_NE(xml.find("<dialog_on_exit>"), std::string::npos);
   EXPECT_NE(xml.find("<plugins"), std::string::npos);
   EXPECT_EQ(xml.find("<ignore>"), std::string::npos);
 }

--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -211,6 +211,7 @@ TEST(WindowConfigTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(defaultValues))
   EXPECT_TRUE(c.materialAccent.empty());
   EXPECT_TRUE(c.showDrawer);
   EXPECT_TRUE(c.showDefaultDrawerOpts);
+  EXPECT_FALSE(c.showDialogOnExit);
   EXPECT_TRUE(c.showPluginMenu);
   EXPECT_TRUE(c.pluginsFromPaths);
   EXPECT_TRUE(c.showPlugins.empty());
@@ -225,6 +226,7 @@ TEST(WindowConfigTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(defaultValues))
   EXPECT_NE(xml.find("<height>"), std::string::npos);
   EXPECT_NE(xml.find("<menus>"), std::string::npos);
   EXPECT_NE(xml.find("<drawer"), std::string::npos);
+  EXPECT_NE(xml.find("<dialog_on_exit>"), std::string::npos);
   EXPECT_NE(xml.find("<plugins"), std::string::npos);
   EXPECT_EQ(xml.find("<ignore>"), std::string::npos);
 }

--- a/test/config/test.config
+++ b/test/config/test.config
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
 
+<window>
+  <dialog_on_exit>false</dialog_on_exit>
+</window>
+
 <plugin filename="TestPlugin">
 </plugin>

--- a/tutorials/04_layout.md
+++ b/tutorials/04_layout.md
@@ -28,6 +28,7 @@ by adding a `<window>` element to the config file. The child elements are:
                     the menu. If `from_paths` is true, all plugins will be shown
                     anyway, so adding `<show>` has no effect. For the plugin to
                     be shown, it must be on the path.
+* `<dialog_on_exit>`: If true, a confirmation dialog will show up when closing the window.
 
 ## Example layout
 


### PR DESCRIPTION
Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>

# 🎉 New feature

Related to https://github.com/ignitionrobotics/ign-gazebo/issues/820

## Summary

A new property (`dialog_on_exit`) was added to the `WindowConfig` struct to enable displaying a confirmation dialog when exiting the window.
In the `.config` file:
```xml
<!-- Window -->
<window>
  <width>1000</width>
  <height>845</height>
  ...
  ...
  <dialog_on_exit>true</dialog_on_exit>    // New Feature
</window>
```
 - Using this property in gazebo: [ign-gazebo branch](https://github.com/ignitionrobotics/ign-gazebo/commit/606a17b6eaac8296a1ee85bef4805f7bfdfcd83b)
 
 

https://user-images.githubusercontent.com/53065142/119691095-a87e1c00-be20-11eb-8128-7812714e1f3d.mp4




<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

## Test it
```
// bring this changes.
cd ign-gui
git checkout francocipollone/citadel_confirmation_dialog
cd ../
// Enable this feature for gazebo app.
// Just one line of code.
cd ign-gazebo
git checkout francocipollone/citadel_confirmation_dialog
// Build and run gazebo.
colcon build --packages-select ign-gui3 ign-gazebo3 
ign gazebo
```
Press the X button or Quit from the menu.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
