### PR TITLE
Avoid grid3D crash

### DIFF
--- a/src/plugins/grid_3d/Grid3D.cc
+++ b/src/plugins/grid_3d/Grid3D.cc
@@ -88,11 +88,11 @@ namespace plugins
   class Grid3DPrivate
   {
     /// brief Parent window
-    public: QQuickWindow *quickWindow;
+    public: QQuickWindow *quickWindow = nullptr;
 
     /// \brief We keep a pointer to the engine and rely on it not being
     /// destroyed, since it is a singleton.
-    public: rendering::RenderEngine *engine;
+    public: rendering::RenderEngine *engine = nullptr;
 
     /// \brief We keep the scene name rather than a shared pointer because we
     /// don't want to share ownership.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Grid3D is crashing because some of the pointers are not properly initialized

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
