### PR TITLE
Add sky tag to the new Scene3D

### DIFF
--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -239,6 +239,11 @@ void IgnRenderer::Initialize()
     scene->SetBackgroundColor(this->backgroundColor);
   }
 
+  if (this->skyEnable)
+  {
+    scene->SetSkyEnabled(true);
+  }
+
   auto root = scene->RootVisual();
 
   // Camera
@@ -616,6 +621,12 @@ void RenderWindowItem::SetSceneTopic(const std::string &_topic)
 }
 
 /////////////////////////////////////////////////
+void RenderWindowItem::SetSkyEnabled(const bool &_sky)
+{
+  this->dataPtr->renderThread->ignRenderer.skyEnable = _sky;
+}
+
+/////////////////////////////////////////////////
 Scene3D::Scene3D()
   : Plugin(), dataPtr(new Scene3DPrivate)
 {
@@ -717,6 +728,14 @@ void Scene3D::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     {
       std::string topic = elem->GetText();
       renderWindow->SetSceneTopic(topic);
+    }
+
+    elem = _pluginElem->FirstChildElement("sky");
+    if (nullptr != elem && nullptr != elem->GetText())
+    {
+      renderWindow->SetSkyEnabled(true);
+      if (!elem->NoChildren())
+        ignwarn << "Child elements of <sky> are not supported yet" << std::endl;
     }
   }
 }

--- a/src/plugins/scene3d/Scene3D.hh
+++ b/src/plugins/scene3d/Scene3D.hh
@@ -160,6 +160,8 @@ namespace plugins
     /// added
     public: std::string sceneTopic;
 
+    public: bool skyEnable = false;
+
     /// \internal
     /// \brief Pointer to private data.
     private: std::unique_ptr<IgnRendererPrivate> dataPtr;
@@ -253,6 +255,8 @@ namespace plugins
     /// The renderer will subscribe to this topic to get updates scene messages
     /// \param[in] _topic Scene topic
     public: void SetSceneTopic(const std::string &_topic);
+
+    public: void SetSkyEnabled(const bool &_sky);
 
     /// \brief Slot called when thread is ready to be started
     public Q_SLOTS: void Ready();

--- a/src/plugins/scene3d/Scene3D.hh
+++ b/src/plugins/scene3d/Scene3D.hh
@@ -160,6 +160,7 @@ namespace plugins
     /// added
     public: std::string sceneTopic;
 
+    /// \brief True if sky is enabled;
     public: bool skyEnable = false;
 
     /// \internal
@@ -256,6 +257,8 @@ namespace plugins
     /// \param[in] _topic Scene topic
     public: void SetSceneTopic(const std::string &_topic);
 
+    /// \brief Set if sky is enabled
+    /// \param[in] _sky True to enable the sky, false otherwise.
     public: void SetSkyEnabled(const bool &_sky);
 
     /// \brief Slot called when thread is ready to be started


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

## Summary

Allow to load sky using the `<sky>` tag

## Test it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

