### PR TITLE
Fix crash when starting Grid3D plugin

### DIFF
--- a/src/plugins/grid_3d/Grid3D.cc
+++ b/src/plugins/grid_3d/Grid3D.cc
@@ -88,11 +88,11 @@ namespace plugins
   class Grid3DPrivate
   {
     /// brief Parent window
-    public: QQuickWindow *quickWindow;
+    public: QQuickWindow *quickWindow{nullptr};
 
     /// \brief We keep a pointer to the engine and rely on it not being
     /// destroyed, since it is a singleton.
-    public: rendering::RenderEngine *engine;
+    public: rendering::RenderEngine *engine{nullptr};
 
     /// \brief We keep the scene name rather than a shared pointer because we
     /// don't want to share ownership.


### PR DESCRIPTION
If `Grid3DPrivate::engine` happens not to be a nullptr during
allocation, it will never be correctly initialized and will later try to
dereference an invalid ptr

Just in case we also initialize quickWindow although it doesn't seem to
be strictly necessary.

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

## Summary

Self-explanatory. I ran into this bug by chance. Just open the Grid3D plugin from the GUI and it will crash (unless you're lucky that Grid3DPrivate::engine ended up being nullptr).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
