### PR TITLE
Detect ign instead of using cmake module to check for ignition-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,11 +68,8 @@ ign_find_package(ignition-msgs5 REQUIRED)
 set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
 #--------------------------------------
-# Find ignition-tools
-ign_find_package(ignition-tools QUIET)
-if (ignition-tools_FOUND)
-  set (HAVE_IGN_TOOLS TRUE)
-endif()
+# Find if ign command is available
+find_program(HAVE_IGN_TOOLS ign)
 
 #--------------------------------------
 # Find QT


### PR DESCRIPTION
Part of ignition-tooling/release-tools#472

I don't detect the conditional installation of the `ign` submodule, the PR just
changed the way of detecting ign for testing. 
