### PR TITLE
Fixed tests

### DIFF
--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -27,7 +27,10 @@
 #include "ignition/gui/Plugin.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./Application_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -29,7 +29,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./Application_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./Application_TEST")),
 };
 
 using namespace ignition;

--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -28,7 +28,10 @@
 
 std::string kTestConfigFile = "/tmp/ign-gui-test.config"; // NOLINT(*)
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./MainWindow_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -30,7 +30,7 @@ std::string kTestConfigFile = "/tmp/ign-gui-test.config"; // NOLINT(*)
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./MainWindow_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./MainWindow_TEST")),
 };
 
 using namespace ignition;

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -91,7 +91,8 @@ Plugin::Plugin() : dataPtr(new PluginPrivate)
 /////////////////////////////////////////////////
 Plugin::~Plugin()
 {
-  delete this->dataPtr->pluginItem;
+  if (this->dataPtr->pluginItem)
+    delete this->dataPtr->pluginItem;
 }
 
 /////////////////////////////////////////////////

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -26,7 +26,10 @@
 #include "ignition/gui/Plugin.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./Plugin_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -28,7 +28,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./Plugin_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./Plugin_TEST")),
 };
 
 using namespace ignition;

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -30,7 +30,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./ignition")),
+  reinterpret_cast<char*>(const_cast<char*>("./ignition")),
 };
 
 //////////////////////////////////////////////////

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -28,7 +28,10 @@
 #include "ignition/gui/MainWindow.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./ignition")),
+};
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE char *ignitionVersion()

--- a/src/plugins/publisher/Publisher_TEST.cc
+++ b/src/plugins/publisher/Publisher_TEST.cc
@@ -34,7 +34,10 @@
 #include "Publisher.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./Publisher_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/plugins/publisher/Publisher_TEST.cc
+++ b/src/plugins/publisher/Publisher_TEST.cc
@@ -36,7 +36,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./Publisher_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./Publisher_TEST")),
 };
 
 using namespace ignition;

--- a/src/plugins/screenshot/Screenshot_TEST.cc
+++ b/src/plugins/screenshot/Screenshot_TEST.cc
@@ -42,7 +42,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./Screenshot_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./Screenshot_TEST")),
 };
 
 using namespace ignition;

--- a/src/plugins/screenshot/Screenshot_TEST.cc
+++ b/src/plugins/screenshot/Screenshot_TEST.cc
@@ -40,7 +40,10 @@
 #include "Screenshot.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./Screenshot_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/plugins/topic_viewer/TopicViewer_TEST.cc
+++ b/src/plugins/topic_viewer/TopicViewer_TEST.cc
@@ -36,7 +36,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./TopicViewer_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./TopicViewer_TEST")),
 };
 
 using namespace ignition;

--- a/src/plugins/topic_viewer/TopicViewer_TEST.cc
+++ b/src/plugins/topic_viewer/TopicViewer_TEST.cc
@@ -34,7 +34,10 @@
 
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./TopicViewer_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/plugins/world_control/WorldControl_TEST.cc
+++ b/src/plugins/world_control/WorldControl_TEST.cc
@@ -28,7 +28,10 @@
 #include "WorldControl.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./WorldControl_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/plugins/world_control/WorldControl_TEST.cc
+++ b/src/plugins/world_control/WorldControl_TEST.cc
@@ -30,7 +30,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./WorldControl_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./WorldControl_TEST")),
 };
 
 using namespace ignition;

--- a/src/plugins/world_stats/WorldStats_TEST.cc
+++ b/src/plugins/world_stats/WorldStats_TEST.cc
@@ -28,7 +28,10 @@
 #include "WorldStats.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./WorldStats_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/src/plugins/world_stats/WorldStats_TEST.cc
+++ b/src/plugins/world_stats/WorldStats_TEST.cc
@@ -30,7 +30,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./WorldStats_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./WorldStats_TEST")),
 };
 
 using namespace ignition;

--- a/test/integration/Examples_TEST.cc
+++ b/test/integration/Examples_TEST.cc
@@ -25,7 +25,10 @@
 #include "ignition/gui/Application.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./Examples_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/test/integration/Examples_TEST.cc
+++ b/test/integration/Examples_TEST.cc
@@ -27,7 +27,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./Examples_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./Examples_TEST")),
 };
 
 using namespace ignition;

--- a/test/integration/scene3d.cc
+++ b/test/integration/scene3d.cc
@@ -34,7 +34,10 @@
 #include "ignition/gui/MainWindow.hh"
 
 int g_argc = 1;
-char **g_argv = new char *[g_argc];
+char* g_argv[] =
+{
+    reinterpret_cast<char*>(const_cast<char*>("./Scene3d_TEST")),
+};
 
 using namespace ignition;
 using namespace gui;

--- a/test/integration/scene3d.cc
+++ b/test/integration/scene3d.cc
@@ -36,7 +36,7 @@
 int g_argc = 1;
 char* g_argv[] =
 {
-    reinterpret_cast<char*>(const_cast<char*>("./Scene3d_TEST")),
+  reinterpret_cast<char*>(const_cast<char*>("./Scene3d_TEST")),
 };
 
 using namespace ignition;


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

According with the official [Qt documentation](https://doc.qt.io/qt-5/qguiapplication.html#QGuiApplication).

```
Warning: The data referred to by argc and argv must stay valid for the entire lifetime of the QGuiApplication object.
In addition, argc must be greater than zero and argv must contain at least one valid character string.
```

These changes should fix the segmentation faults

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

