### PR TITLE
Remove windows warnings in CameraTracking

### DIFF
--- a/test/integration/camera_tracking.cc
+++ b/test/integration/camera_tracking.cc
@@ -19,7 +19,15 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/math/Pose3.hh>
+
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
 #include <ignition/msgs/pose.pb.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <ignition/rendering/Camera.hh>
 #include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/RenderingIface.hh>
@@ -202,4 +210,3 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
     EXPECT_GT(10, abs(camera->WorldPose().Pos().Z() - it));
   }
 }
-


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Remove windows warnings in INTEGRATION_CameraTracking generated by `pose.pb.h`

## Checklist
- [x] Signed all commits for DCO
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
