### PR TITLE
4 to 5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,27 @@
 
 ### Ignition Gui 4.X.X (20XX-XX-XX)
 
+
+### Ignition Gui 4.5.0 (2021-07-26)
+
+1. New teleop plugin implementation.
+    * [Pull request #245](https://github.com/ignitionrobotics/ign-gui/pull/245)
+
+1. Fix codeowners
+    * [Pull request #251](https://github.com/ignitionrobotics/ign-gui/pull/251)
+
+1. Fix plugin added signal, add PluginByName
+    * [Pull request #249](https://github.com/ignitionrobotics/ign-gui/pull/249)
+
+1. Fixed tests by passing valid argv
+    * [Pull request #244](https://github.com/ignitionrobotics/ign-gui/pull/244)
+
+1. Screenshot plugin fixed dbg message
+    * [Pull request #246](https://github.com/ignitionrobotics/ign-gui/pull/246)
+
+1. Detect ign instead of using cmake module to check for ignition-tools
+    * [Pull request #240](https://github.com/ignitionrobotics/ign-gui/pull/240)
+
 ### Ignition Gui 4.4.0 (2021-06-21)
 
 1. Bump required ign-rendering version to 4.8

--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,11 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition GUI 4.4 to 4.5
+
+* The `Application::PluginAdded` signal used to send empty strings. Now it
+  sends the plugin's unique name.
+
 ## Ignition GUI 3.x to 4.x
 
 * Use rendering4, transport9 and msgs6.


### PR DESCRIPTION
# ➡️ Forward port

Port `ign-gui4` to `ign-gui5`

Branch comparison: https://github.com/ignitionrobotics/ign-gui/compare/ign-gui5...ign-gui4

I'm making this forward port before making an `ign-gui5` release so that we have the most up-to-date change log and migration guide.

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)