### PR TITLE
Emit ignition gui key events in minimal scene3D

### DIFF
--- a/include/ignition/gui/Conversions.hh
+++ b/include/ignition/gui/Conversions.hh
@@ -25,6 +25,8 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+#include <ignition/common/KeyEvent.hh>
+#include <ignition/common/MouseEvent.hh>
 #include <ignition/common/Time.hh>
 #include <ignition/math/Color.hh>
 #include <ignition/math/Vector2.hh>
@@ -86,6 +88,13 @@ namespace ignition
     /// \return Ignition mouse event
     IGNITION_GUI_VISIBLE
     common::MouseEvent convert(const QMouseEvent &_e);
+
+    /// \brief Return the equivalent ignition key event.
+    ///
+    /// \param[in] _e Qt key event
+    /// \return Ignition key event
+    IGNITION_GUI_VISIBLE
+    common::KeyEvent convert(const QKeyEvent &_e);
   }
 }
 #endif

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -121,6 +121,19 @@ ignition::common::KeyEvent ignition::gui::convert(const QKeyEvent &_e)
   event.SetKey(_e.key());
   event.SetText(_e.text().toStdString());
 
+  if (_e.type() == QEvent::KeyPress)
+  {
+    event.SetType(common::KeyEvent::PRESS);
+  }
+  else if (_e.type() == QEvent::KeyRelease)
+  {
+    event.SetType(common::KeyEvent::RELEASE);
+  }
+  else
+  {
+    event.SetType(common::KeyEvent::NO_EVENT);
+  }
+
   event.SetControl(
     (_e.modifiers() & Qt::ControlModifier)
     && (_e.key() == Qt::Key_Control));

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -134,15 +134,9 @@ ignition::common::KeyEvent ignition::gui::convert(const QKeyEvent &_e)
     event.SetType(common::KeyEvent::NO_EVENT);
   }
 
-  event.SetControl(
-    (_e.modifiers() & Qt::ControlModifier)
-    && (_e.key() == Qt::Key_Control));
-  event.SetShift(
-    (_e.modifiers() & Qt::ShiftModifier)
-    && (_e.key() == Qt::Key_Shift));
-  event.SetAlt(
-    (_e.modifiers() & Qt::AltModifier)
-    && (_e.key() == Qt::Key_Alt));
+  event.SetControl(_e.modifiers() & Qt::ControlModifier);
+  event.SetShift(_e.modifiers() & Qt::ShiftModifier);
+  event.SetAlt(_e.modifiers() & Qt::AltModifier);
 
   return event;
 }

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <ignition/common/KeyEvent.hh>
 #include <ignition/common/MouseEvent.hh>
 #include <ignition/math/Color.hh>
 
@@ -113,3 +114,22 @@ ignition::common::MouseEvent ignition::gui::convert(const QMouseEvent &_e)
   return event;
 }
 
+//////////////////////////////////////////////////
+ignition::common::KeyEvent ignition::gui::convert(const QKeyEvent &_e)
+{
+  common::KeyEvent event;
+  event.SetKey(_e.key());
+  event.SetText(_e.text().toStdString());
+
+  event.SetControl(
+    (_e.modifiers() & Qt::ControlModifier)
+    && (_e.key() == Qt::Key_Control));
+  event.SetShift(
+    (_e.modifiers() & Qt::ShiftModifier)
+    && (_e.key() == Qt::Key_Shift));
+  event.SetAlt(
+    (_e.modifiers() & Qt::AltModifier)
+    && (_e.key() == Qt::Key_Alt));
+
+  return event;
+}

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -148,3 +148,27 @@ TEST(ConversionsTest, MouseEvent)
   }
 }
 
+/////////////////////////////////////////////////
+TEST(ConversionsTest, KeyEvent)
+{
+  {
+    QKeyEvent qtEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    auto ignEvent = convert(qtEvent);
+
+    EXPECT_EQ(ignEvent.Type(), common::KeyEvent::PRESS);
+    EXPECT_EQ(ignEvent.Key(), Qt::Key_Escape);
+    EXPECT_FALSE(ignEvent.Control());
+    EXPECT_FALSE(ignEvent.Shift());
+    EXPECT_FALSE(ignEvent.Alt());
+  }
+  {
+    QKeyEvent qtEvent(QEvent::KeyRelease, Qt::Key_Control, Qt::NoModifier);
+    auto ignEvent = convert(qtEvent);
+
+    EXPECT_EQ(ignEvent.Type(), common::KeyEvent::RELEASE);
+    EXPECT_EQ(ignEvent.Key(), Qt::Key_Control);
+    EXPECT_TRUE(ignEvent.Control());
+    EXPECT_FALSE(ignEvent.Shift());
+    EXPECT_FALSE(ignEvent.Alt());
+  }
+}

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -152,13 +152,14 @@ TEST(ConversionsTest, MouseEvent)
 TEST(ConversionsTest, KeyEvent)
 {
   {
-    QKeyEvent qtEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    QKeyEvent qtEvent(QEvent::KeyPress, Qt::Key_Escape,
+        Qt::ShiftModifier | Qt::ControlModifier);
     auto ignEvent = convert(qtEvent);
 
     EXPECT_EQ(ignEvent.Type(), common::KeyEvent::PRESS);
     EXPECT_EQ(ignEvent.Key(), Qt::Key_Escape);
-    EXPECT_FALSE(ignEvent.Control());
-    EXPECT_FALSE(ignEvent.Shift());
+    EXPECT_TRUE(ignEvent.Control());
+    EXPECT_TRUE(ignEvent.Shift());
     EXPECT_FALSE(ignEvent.Alt());
   }
   {
@@ -170,5 +171,15 @@ TEST(ConversionsTest, KeyEvent)
     EXPECT_TRUE(ignEvent.Control());
     EXPECT_FALSE(ignEvent.Shift());
     EXPECT_FALSE(ignEvent.Alt());
+  }
+  {
+    QKeyEvent qtEvent(QEvent::None, Qt::Key_R, Qt::AltModifier);
+    auto ignEvent = convert(qtEvent);
+
+    EXPECT_EQ(ignEvent.Type(), common::KeyEvent::NO_EVENT);
+    EXPECT_EQ(ignEvent.Key(), Qt::Key_R);
+    EXPECT_FALSE(ignEvent.Control());
+    EXPECT_FALSE(ignEvent.Shift());
+    EXPECT_TRUE(ignEvent.Alt());
   }
 }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -170,38 +170,27 @@ void IgnRenderer::HandleMouseViewControl()
 }
 
 ////////////////////////////////////////////////
-void IgnRenderer::HandleKeyPress(common::KeyEvent &_e)
+void IgnRenderer::HandleKeyPress(const common::KeyEvent &_e)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
-  this->dataPtr->keyEvent.SetKey(_e.Key());
-  this->dataPtr->keyEvent.SetText(_e.Text());
-
-  this->dataPtr->keyEvent.SetControl(_e.Control());
-  this->dataPtr->keyEvent.SetShift(_e.Shift());
-  this->dataPtr->keyEvent.SetAlt(_e.Alt());
+  this->dataPtr->keyEvent = _e;
 
   this->dataPtr->mouseEvent.SetControl(this->dataPtr->keyEvent.Control());
   this->dataPtr->mouseEvent.SetShift(this->dataPtr->keyEvent.Shift());
   this->dataPtr->mouseEvent.SetAlt(this->dataPtr->keyEvent.Alt());
-  this->dataPtr->keyEvent.SetType(_e.Type());
 }
 
 ////////////////////////////////////////////////
-void IgnRenderer::HandleKeyRelease(common::KeyEvent &_e)
+void IgnRenderer::HandleKeyRelease(const common::KeyEvent &_e)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
-  this->dataPtr->keyEvent.SetKey(_e.Key());
-
-  this->dataPtr->keyEvent.SetControl(_e.Control());
-  this->dataPtr->keyEvent.SetShift(_e.Shift());
-  this->dataPtr->keyEvent.SetAlt(_e.Alt());
+  this->dataPtr->keyEvent = _e;
 
   this->dataPtr->mouseEvent.SetControl(this->dataPtr->keyEvent.Control());
   this->dataPtr->mouseEvent.SetShift(this->dataPtr->keyEvent.Shift());
   this->dataPtr->mouseEvent.SetAlt(this->dataPtr->keyEvent.Alt());
-  this->dataPtr->keyEvent.SetType(_e.Type());
 }
 
 /////////////////////////////////////////////////
@@ -879,13 +868,13 @@ void RenderWindowItem::wheelEvent(QWheelEvent *_e)
 }
 
 ////////////////////////////////////////////////
-void RenderWindowItem::HandleKeyPress(common::KeyEvent &_e)
+void RenderWindowItem::HandleKeyPress(const common::KeyEvent &_e)
 {
   this->dataPtr->renderThread->ignRenderer.HandleKeyPress(_e);
 }
 
 ////////////////////////////////////////////////
-void RenderWindowItem::HandleKeyRelease(common::KeyEvent &_e)
+void RenderWindowItem::HandleKeyRelease(const common::KeyEvent &_e)
 {
   this->dataPtr->renderThread->ignRenderer.HandleKeyRelease(_e);
 }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -185,9 +185,6 @@ void IgnRenderer::HandleKeyPress(common::KeyEvent &_e)
   this->dataPtr->mouseEvent.SetShift(this->dataPtr->keyEvent.Shift());
   this->dataPtr->mouseEvent.SetAlt(this->dataPtr->keyEvent.Alt());
   this->dataPtr->keyEvent.SetType(_e.Type());
-
-  events::KeyPressOnScene keyReleaseOnSceneEvent(this->dataPtr->keyEvent);
-  App()->sendEvent(App()->findChild<MainWindow *>(), &keyReleaseOnSceneEvent);
 }
 
 ////////////////////////////////////////////////
@@ -205,9 +202,6 @@ void IgnRenderer::HandleKeyRelease(common::KeyEvent &_e)
   this->dataPtr->mouseEvent.SetShift(this->dataPtr->keyEvent.Shift());
   this->dataPtr->mouseEvent.SetAlt(this->dataPtr->keyEvent.Alt());
   this->dataPtr->keyEvent.SetType(_e.Type());
-
-  events::KeyPressOnScene keyPressOnSceneEvent(this->dataPtr->keyEvent);
-  App()->sendEvent(App()->findChild<MainWindow *>(), &keyPressOnSceneEvent);
 }
 
 /////////////////////////////////////////////////
@@ -834,8 +828,6 @@ void RenderWindowItem::keyPressEvent(QKeyEvent *_e)
     return;
 
   auto event = convert(*_e);
-  event.SetType(common::KeyEvent::PRESS);
-  std::cerr << "control Pressed " << event.Control() << '\n';
   this->HandleKeyPress(event);
 }
 
@@ -846,7 +838,6 @@ void RenderWindowItem::keyReleaseEvent(QKeyEvent *_e)
     return;
 
   auto event = convert(*_e);
-  event.SetType(common::KeyEvent::RELEASE);
   this->HandleKeyPress(event);
 }
 
@@ -897,13 +888,6 @@ void RenderWindowItem::HandleKeyPress(common::KeyEvent &_e)
 void RenderWindowItem::HandleKeyRelease(common::KeyEvent &_e)
 {
   this->dataPtr->renderThread->ignRenderer.HandleKeyRelease(_e);
-}
-
-/////////////////////////////////////////////////
-bool MinimalScene::eventFilter(QObject *_obj, QEvent *_event)
-{
-  // Standard event processing
-  return QObject::eventFilter(_obj, _event);
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -108,11 +108,11 @@ namespace plugins
 
     /// \brief Handle key press event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyPress(ignition::common::KeyEvent &_e);
+    public: void HandleKeyPress(const common::KeyEvent &_e);
 
     /// \brief Handle key release event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyRelease(ignition::common::KeyEvent &_e);
+    public: void HandleKeyRelease(const common::KeyEvent &_e);
 
     /// \brief Handle mouse event for view control
     private: void HandleMouseEvent();
@@ -293,11 +293,11 @@ namespace plugins
 
     /// \brief Handle key press event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyPress(ignition::common::KeyEvent &_e);
+    public: void HandleKeyPress(const common::KeyEvent &_e);
 
     /// \brief Handle key release event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyRelease(ignition::common::KeyEvent &_e);
+    public: void HandleKeyRelease(const common::KeyEvent &_e);
 
     // Documentation inherited
     protected: virtual void mousePressEvent(QMouseEvent *_e) override;
@@ -309,10 +309,10 @@ namespace plugins
     protected: virtual void mouseMoveEvent(QMouseEvent *_e) override;
 
     // Documentation inherited
-    protected: virtual void keyPressEvent(QKeyEvent *event) override;
+    protected: virtual void keyPressEvent(QKeyEvent *_e) override;
 
     // Documentation inherited
-    protected: virtual void keyReleaseEvent(QKeyEvent *event) override;
+    protected: virtual void keyReleaseEvent(QKeyEvent *_e) override;
 
     // Documentation inherited
     protected: virtual void wheelEvent(QWheelEvent *_e) override;

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -70,9 +70,6 @@ namespace plugins
     public slots: void OnFocusWindow();
 
     // Documentation inherited
-    protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
-
-    // Documentation inherited
     public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         override;
 
@@ -312,10 +309,10 @@ namespace plugins
     protected: virtual void mouseMoveEvent(QMouseEvent *_e) override;
 
     // Documentation inherited
-    protected: virtual void keyPressEvent(QKeyEvent *event);
+    protected: virtual void keyPressEvent(QKeyEvent *event) override;
 
     // Documentation inherited
-    protected: virtual void keyReleaseEvent(QKeyEvent *event);
+    protected: virtual void keyReleaseEvent(QKeyEvent *event) override;
 
     // Documentation inherited
     protected: virtual void wheelEvent(QWheelEvent *_e) override;

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -21,6 +21,7 @@
 #include <string>
 #include <memory>
 
+#include <ignition/common/KeyEvent.hh>
 #include <ignition/common/MouseEvent.hh>
 #include <ignition/math/Color.hh>
 #include <ignition/math/Pose3.hh>
@@ -110,11 +111,11 @@ namespace plugins
 
     /// \brief Handle key press event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyPress(QKeyEvent *_e);
+    public: void HandleKeyPress(ignition::common::KeyEvent &_e);
 
     /// \brief Handle key release event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyRelease(QKeyEvent *_e);
+    public: void HandleKeyRelease(ignition::common::KeyEvent &_e);
 
     /// \brief Handle mouse event for view control
     private: void HandleMouseEvent();
@@ -130,6 +131,12 @@ namespace plugins
 
     /// \brief Broadcasts a right click within the scene
     private: void BroadcastRightClick();
+
+    /// \brief Broadcasts a key release event within the scene
+    private: void BroadcastKeyRelease();
+
+    /// \brief Broadcasts a key press event within the scene
+    private: void BroadcastKeyPress();
 
     /// \brief Retrieve the first point on a surface in the 3D scene hit by a
     /// ray cast from the given 2D screen coordinates.
@@ -289,11 +296,11 @@ namespace plugins
 
     /// \brief Handle key press event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyPress(QKeyEvent *_e);
+    public: void HandleKeyPress(ignition::common::KeyEvent &_e);
 
     /// \brief Handle key release event for snapping
     /// \param[in] _e The key event to process.
-    public: void HandleKeyRelease(QKeyEvent *_e);
+    public: void HandleKeyRelease(ignition::common::KeyEvent &_e);
 
     // Documentation inherited
     protected: virtual void mousePressEvent(QMouseEvent *_e) override;
@@ -303,6 +310,12 @@ namespace plugins
 
     // Documentation inherited
     protected: virtual void mouseMoveEvent(QMouseEvent *_e) override;
+
+    // Documentation inherited
+    protected: virtual void keyPressEvent(QKeyEvent *event);
+
+    // Documentation inherited
+    protected: virtual void keyReleaseEvent(QKeyEvent *event);
 
     // Documentation inherited
     protected: virtual void wheelEvent(QWheelEvent *_e) override;


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 Enhancement

## Summary

Required by https://github.com/ignitionrobotics/ign-gazebo/pull/854

This PR emit KeyEvent using ignition gui events

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
