### PR TITLE
Added log storing for ign-gui

### DIFF
--- a/src/ign.cc
+++ b/src/ign.cc
@@ -34,22 +34,28 @@ char* g_argv[] =
 };
 
 //////////////////////////////////////////////////
-extern "C" IGNITION_GUI_VISIBLE char *ignitionVersion()
+void startConsoleLog()
 {
   std::string home;
   ignition::common::env(IGN_HOMEDIR, home);
 
-  std::string recordPathMod = ignition::common::joinPaths(home,
-        ".ignition", "gazebo", "log",ignition::common::timeToIso(IGN_SYSTEM_TIME()));
-  ignLogInit(recordPathMod, "gui_console.log");
+  std::string logPathMod = ignition::common::joinPaths(home,
+      ".ignition", "gui", "log",
+      ignition::common::timeToIso(IGN_SYSTEM_TIME()));
+  ignLogInit(logPathMod, "console.log");
+}
 
-
+//////////////////////////////////////////////////
+extern "C" IGNITION_GUI_VISIBLE char *ignitionVersion()
+{
   return strdup(IGNITION_GUI_VERSION_FULL);
 }
 
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE void cmdPluginList()
 {
+  startConsoleLog();
+
   ignition::gui::Application app(g_argc, g_argv);
 
   auto pluginsList = app.PluginList();
@@ -73,6 +79,8 @@ extern "C" IGNITION_GUI_VISIBLE void cmdPluginList()
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE void cmdStandalone(const char *_filename)
 {
+  startConsoleLog();
+
   ignition::gui::Application app(g_argc, g_argv,
       ignition::gui::WindowType::kDialog);
 
@@ -87,6 +95,8 @@ extern "C" IGNITION_GUI_VISIBLE void cmdStandalone(const char *_filename)
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE void cmdConfig(const char *_config)
 {
+  startConsoleLog();
+
   ignition::gui::Application app(g_argc, g_argv);
 
   if (!app.findChild<ignition::gui::MainWindow *>())
@@ -111,6 +121,8 @@ extern "C" IGNITION_GUI_VISIBLE void cmdVerbose(const char *_verbosity)
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE void cmdEmptyWindow()
 {
+  startConsoleLog();
+
   ignition::gui::Application app(g_argc, g_argv);
 
   if (!app.findChild<ignition::gui::MainWindow *>())

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -36,6 +36,14 @@ char* g_argv[] =
 //////////////////////////////////////////////////
 extern "C" IGNITION_GUI_VISIBLE char *ignitionVersion()
 {
+  std::string home;
+  ignition::common::env(IGN_HOMEDIR, home);
+
+  std::string recordPathMod = ignition::common::joinPaths(home,
+        ".ignition", "gazebo", "log",ignition::common::timeToIso(IGN_SYSTEM_TIME()));
+  ignLogInit(recordPathMod, "gui_console.log");
+
+
   return strdup(IGNITION_GUI_VERSION_FULL);
 }
 

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
@@ -52,10 +54,43 @@ std::string custom_exec_str(std::string _cmd)
   return result;
 }
 
-// See https://github.com/ignitionrobotics/ign-gui/issues/75
-TEST(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
+using namespace ignition;
+
+class CmdLine : public ::testing::Test
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    // Change environment variable so that test files aren't written to $HOME
+    common::env(IGN_HOMEDIR, this->realHome);
+    EXPECT_TRUE(common::setenv(IGN_HOMEDIR, this->kFakeHome.c_str()));
+  }
+
+  // Documentation inherited
+  protected: void TearDown() override
+  {
+    // Restore $HOME
+    EXPECT_TRUE(common::setenv(IGN_HOMEDIR, this->realHome.c_str()));
+  }
+
+  /// \brief Directory to act as $HOME for tests
+  public: const std::string kFakeHome = common::joinPaths(PROJECT_BINARY_PATH,
+      "test", "fake_home");
+
+  /// \brief Store user's real $HOME to set it back at the end of tests.
+  public: std::string realHome;
+};
+
+// See https://github.com/ignitionrobotics/ign-gui/issues/75
+TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
+{
+  EXPECT_TRUE(common::removeAll(this->kFakeHome));
+  EXPECT_FALSE(common::exists(this->kFakeHome));
+
   std::string output = custom_exec_str("ign gui -l");
   EXPECT_NE(output.find("TopicEcho"), std::string::npos) << output;
   EXPECT_NE(output.find("Publisher"), std::string::npos) << output;
+
+  EXPECT_TRUE(common::exists(common::joinPaths(this->kFakeHome, ".ignition",
+      "gui")));
 }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -84,7 +84,9 @@ class CmdLine : public ::testing::Test
 // See https://github.com/ignitionrobotics/ign-gui/issues/75
 TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
 {
-  EXPECT_TRUE(common::removeAll(this->kFakeHome));
+  // Clear home if it exists
+  common::removeAll(this->kFakeHome);
+
   EXPECT_FALSE(common::exists(this->kFakeHome));
 
   std::string output = custom_exec_str("ign gui -l");

--- a/tutorials/02_commandline.md
+++ b/tutorials/02_commandline.md
@@ -32,3 +32,6 @@ If you have Ignition Tools installed, you can use the `ign gui` command line too
       --force-version <VERSION>  Use a specific library version.
 
       --versions                 Show the available versions.
+
+When using the command line tool, all console messages are logged to
+`$HOME/.ignition/gui/log/<timestamp>`.


### PR DESCRIPTION
# 🎉 New feature

Closes [#962](https://github.com/ignitionrobotics/ign-gazebo/issues/962) from ign-gazebo repository

## Summary
Every time a simulation is run with the GUI, the GUI console logs are saved to ~/.ignition/gazebo/log/<timestamp>/gui_console.log

## Test it
Run a simulation. Then :
`cd /.ignition/gazebo/log/<TIMESTAMP>

cat gui_console.log`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**


