### PR TITLE
Add SpawnCloneFromName event

### DIFF
--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -216,6 +216,46 @@ namespace ignition
         IGN_UTILS_IMPL_PTR(dataPtr)
       };
 
+      /// \brief Event which is called to broadcast the key release within
+      /// the scene.
+      class IGNITION_GUI_VISIBLE KeyReleaseOnScene : public QEvent
+      {
+        /// \brief Constructor
+        /// \param[in] _key The key released event within the scene
+        public: explicit KeyReleaseOnScene(const common::KeyEvent &_key);
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 8);
+
+        /// \brief Get the released key within the scene that the user released.
+        /// \return The key code.
+        public: common::KeyEvent Key() const;
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
+
+      /// \brief Event which is called to broadcast the key press within
+      /// the scene.
+      class IGNITION_GUI_VISIBLE KeyPressOnScene : public QEvent
+      {
+        /// \brief Constructor
+        /// \param[in] _key The pressed key within the scene
+        public: explicit KeyPressOnScene(const common::KeyEvent &_key);
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 9);
+
+        /// \brief Get the key within the scene that the user pressed
+        /// \return The key code.
+        public: common::KeyEvent Key() const;
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
+
       /// \brief Event which is called to broadcast information about left
       /// mouse clicks on the scene.
       /// For the 3D coordinates of that point on the scene, see
@@ -256,46 +296,6 @@ namespace ignition
 
         /// \brief Return the right mouse event
         public: const common::MouseEvent &Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        IGN_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the key release within
-      /// the scene.
-      class IGNITION_GUI_VISIBLE KeyReleaseOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _key The key released event within the scene
-        public: explicit KeyReleaseOnScene(const common::KeyEvent &_key);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 8);
-
-        /// \brief Get the released key within the scene that the user released.
-        /// \return The key code.
-        public: common::KeyEvent Key() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        IGN_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the key press within
-      /// the scene.
-      class IGNITION_GUI_VISIBLE KeyPressOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _key The pressed key within the scene
-        public: explicit KeyPressOnScene(const common::KeyEvent &_key);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 9);
-
-        /// \brief Get the key within the scene that the user pressed
-        /// \return The key code.
-        public: common::KeyEvent Key() const;
 
         /// \internal
         /// \brief Private data pointer
@@ -346,6 +346,24 @@ namespace ignition
         IGN_UTILS_IMPL_PTR(dataPtr)
       };
 
+      /// \brief Event called to clone a resource, given its name as a string.
+      class IGNITION_GUI_VISIBLE SpawnCloneFromName : public QEvent
+      {
+        /// \brief Constructor
+        /// \param[in] _name The name of the resource to clone
+        public: explicit SpawnCloneFromName(const std::string &_name);
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 14);
+
+        /// \brief Get the name of the resource to be cloned
+        /// \return The name of the resource to be cloned
+        public: const std::string &Name() const;
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
     }
   }
 }

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -103,6 +103,12 @@ class ignition::gui::events::KeyPressOnScene::Implementation
   public: common::KeyEvent key;
 };
 
+class ignition::gui::events::SpawnCloneFromName::Implementation
+{
+  /// \brief The name of the resource to be cloned
+  public: std::string name;
+};
+
 using namespace ignition;
 using namespace gui;
 using namespace events;
@@ -293,4 +299,18 @@ KeyPressOnScene::KeyPressOnScene(
 common::KeyEvent KeyPressOnScene::Key() const
 {
   return this->dataPtr->key;
+}
+
+/////////////////////////////////////////////////
+SpawnCloneFromName::SpawnCloneFromName(
+  const std::string &_name)
+    : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->name = _name;
+}
+
+/////////////////////////////////////////////////
+const std::string &SpawnCloneFromName::Name() const
+{
+  return this->dataPtr->name;
 }

--- a/src/GuiEvents_TEST.cc
+++ b/src/GuiEvents_TEST.cc
@@ -193,3 +193,12 @@ TEST(GuiEventsTest, BlockOrbit)
   EXPECT_LT(QEvent::User, event2.type());
   EXPECT_FALSE(event2.Block());
 }
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, SpawnCloneFromName)
+{
+  events::SpawnCloneFromName toCloneName("thingToClone");
+
+  EXPECT_LT(QEvent::User, toCloneName.type());
+  EXPECT_EQ("thingToClone", toCloneName.Name());
+}


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🎉 New feature

## Summary
I've added a `SpawnCloneFromName` event which can be used for things like copy/paste: see https://github.com/ignitionrobotics/ign-gazebo/pull/1013

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**