### PR TITLE
Fix memory leak in ImageDisplay.cc

### DIFF
--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -212,6 +212,8 @@ void ImageDisplay::ProcessImage()
         image.setPixel(i, j, value);
       }
     }
+
+    delete [] data;
   }
 
   this->dataPtr->provider->SetImage(image);


### PR DESCRIPTION
## Summary

**Note:** This is a big memory leak in the order of 30 MB/s or more depending on many conditions; thus it should be prioritized. A 32GB RAM machine can run out of memory after approximately 20 min of real time simulation.

I don't like the interface of common::Image outputting a raw pointer that is deleted if the input is non-nullptr but it is up to the caller to the delete if it's not called again. And it's not documented either.
I don't like the amount of unnecessary copies required by `ImageDisplay::ProcessImage` either. Or the fact that we do one allocation per frame (instead of trying to keep an allocated region while in use).

*But all those are problems for another day*.

Don't forget to merge this to ign-gui5 and later :)

# 🦟 Bug fix

Fixes ignitionrobotics/ign-gazebo#1011


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
