### PR TITLE
Added winID to fix second windows in OGRE2.2

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -466,6 +466,9 @@ void IgnRenderer::Initialize()
 
   std::map<std::string, std::string> params;
   params["useCurrentGLContext"] = "1";
+  params["winID"] = std::to_string(
+    ignition::gui::App()->findChild<ignition::gui::MainWindow *>()->
+      QuickWindow()->winId());
   auto engine = rendering::engine(this->engineName, params);
   if (!engine)
   {

--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -1116,6 +1116,11 @@ void IgnRenderer::Initialize()
 
   std::map<std::string, std::string> params;
   params["useCurrentGLContext"] = "1";
+  params["winID"] = std::to_string(
+    ignition::gui::App()->findChild<ignition::gui::MainWindow *>()->
+      QuickWindow()->winId());
+  ignerr << "params[\"winID\"] " << params["winID"] << std::endl;
+
   auto engine = rendering::engine(this->engineName, params);
   if (!engine)
   {

--- a/src/plugins/scene3d/Scene3D.cc
+++ b/src/plugins/scene3d/Scene3D.cc
@@ -1119,7 +1119,6 @@ void IgnRenderer::Initialize()
   params["winID"] = std::to_string(
     ignition::gui::App()->findChild<ignition::gui::MainWindow *>()->
       QuickWindow()->winId());
-  ignerr << "params[\"winID\"] " << params["winID"] << std::endl;
 
   auto engine = rendering::engine(this->engineName, params);
   if (!engine)


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Fix https://github.com/ignitionrobotics/ign-gui/issues/291

Requires a PR in ign-rendering6

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
