### PR TITLE
Sort out MinimalScene's mouse events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,61 @@
 
 ### Ignition Gui 6.X.X
 
-### Ignition Gui 6.0.0 (20XX-XX-XX)
+### Ignition Gui 6.0.0 (2021-09-XX)
+
+1. Render engine GUI name argument to be set in the minimal scene
+    * [Pull request #286](https://github.com/ignitionrobotics/ign-gui/pull/286)
+
+1. New events
+
+    1. Drop
+        * [Pull request #282](https://github.com/ignitionrobotics/ign-gui/pull/282)
+
+    1. SpawnCloneFromName
+        * [Pull request #278](https://github.com/ignitionrobotics/ign-gui/pull/278)
+
+    1. HoverOnScene
+        * [Pull request #273](https://github.com/ignitionrobotics/ign-gui/pull/273)
+
+    1. Mouse Events based on ignition::common
+        * [Pull request #228](https://github.com/ignitionrobotics/ign-gui/pull/228)
+
+1. New plugins
+
+    1. Interactive view control
+        * [Pull request #231](https://github.com/ignitionrobotics/ign-gui/pull/231)
+
+    1. Marker Manager
+        * [Pull request #247](https://github.com/ignitionrobotics/ign-gui/pull/247)
+
+    1. Moved tape measure and grid config from ign-gazebo to ign-gui
+        * [Pull request #236](https://github.com/ignitionrobotics/ign-gui/pull/236)
+
+1. PIMPL GUI events
+    * [Pull request #253](https://github.com/ignitionrobotics/ign-gui/pull/253)
+
+1. Added camera tracking
+    * [Pull request #226](https://github.com/ignitionrobotics/ign-gui/pull/226)
+    * [Pull request #254](https://github.com/ignitionrobotics/ign-gui/pull/254)
+
+1. Split transport scene manager into a plugin outside Scene3D. Adds MinimalScene
+    * [Pull request #221](https://github.com/ignitionrobotics/ign-gui/pull/221)
+    * [Pull request #284](https://github.com/ignitionrobotics/ign-gui/pull/284)
+    * [Pull request #285](https://github.com/ignitionrobotics/ign-gui/pull/285)
+    * [Pull request #268](https://github.com/ignitionrobotics/ign-gui/pull/268)
+    * [Pull request #224](https://github.com/ignitionrobotics/ign-gui/pull/224)
+
+1. Remove deprecations: tock
+    * [Pull request #243](https://github.com/ignitionrobotics/ign-gui/pull/243)
+
+1. Depend on ign-msgs8, ign-transport11, ign-rendering6
+    * [Pull request #210](https://github.com/ignitionrobotics/ign-gui/pull/210)
+
+1. Infrastructure
+    * [Pull request #207](https://github.com/ignitionrobotics/ign-gui/pull/207)
+    * [Pull request #219](https://github.com/ignitionrobotics/ign-gui/pull/219)
+    * [Pull request #266](https://github.com/ignitionrobotics/ign-gui/pull/266)
+    * [Pull request #274](https://github.com/ignitionrobotics/ign-gui/pull/274)
 
 ## Ignition Gui 5
 

--- a/include/ignition/gui/Conversions.hh
+++ b/include/ignition/gui/Conversions.hh
@@ -44,13 +44,13 @@ namespace ignition
 
   namespace gui
   {
-    /// \brief Return the equivalent qt color
+    /// \brief Return the equivalent Qt color
     /// \param[in] _color Ignition color to convert
     /// \return Qt color value
     IGNITION_GUI_VISIBLE
     QColor convert(const math::Color &_color);
 
-    /// \brief Return the equivalent ignition color
+    /// \brief Return the equivalent Ignition color
     /// \param[in] _color Qt color to convert
     /// \return Ignition color value
     IGNITION_GUI_VISIBLE
@@ -62,25 +62,25 @@ namespace ignition
     IGNITION_GUI_VISIBLE
     QPointF convert(const math::Vector2d &_pt);
 
-    /// \brief Return the equivalent ignition vector.
+    /// \brief Return the equivalent Ignition vector.
     /// \param[in] _pt QPointF to convert
     /// \return Ignition Vector2d.
     IGNITION_GUI_VISIBLE
     math::Vector2d convert(const QPointF &_pt);
 
-    /// \brief Return the equivalent qt vector 3d.
+    /// \brief Return the equivalent Qt vector 3d.
     /// \param[in] _vec Ignition vector 3d to convert.
     /// \return Qt vector 3d value.
     IGNITION_GUI_VISIBLE
     QVector3D convert(const math::Vector3d &_vec);
 
-    /// \brief Return the equivalent ignition vector 3d.
+    /// \brief Return the equivalent Ignition vector 3d.
     /// \param[in] _vec Qt vector 3d to convert.
     /// \return Ignition vector 3d value
     IGNITION_GUI_VISIBLE
     math::Vector3d convert(const QVector3D &_vec);
 
-    /// \brief Return the equivalent ignition mouse event.
+    /// \brief Return the equivalent Ignition mouse event.
     ///
     /// Note that there isn't a 1-1 mapping between these types, so fields such
     /// as common::MouseEvent::PressPos need to be set afterwards.
@@ -88,6 +88,14 @@ namespace ignition
     /// \return Ignition mouse event
     IGNITION_GUI_VISIBLE
     common::MouseEvent convert(const QMouseEvent &_e);
+
+    /// \brief Return the equivalent Ignition mouse event.
+    ///
+    /// Note that there isn't a 1-1 mapping between these types.
+    /// \param[in] _e Qt wheel event
+    /// \return Ignition mouse event
+    IGNITION_GUI_VISIBLE
+    common::MouseEvent convert(const QWheelEvent &_e);
 
     /// \brief Return the equivalent ignition key event.
     ///

--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -151,7 +151,7 @@ namespace ignition
       };
 
       /// \brief Event which is called to broadcast the 3D coordinates of a
-      /// user's left click within the scene.
+      /// user's releasing the left button within the scene.
       /// \sa LeftClickOnScene
       class IGNITION_GUI_VISIBLE LeftClickToScene : public QEvent
       {
@@ -173,7 +173,7 @@ namespace ignition
       };
 
       /// \brief Event which is called to broadcast the 3D coordinates of a
-      /// user's right click within the scene.
+      /// user's releasing the right button within the scene.
       /// \sa RightClickOnScene
       class IGNITION_GUI_VISIBLE RightClickToScene : public QEvent
       {
@@ -257,7 +257,7 @@ namespace ignition
       };
 
       /// \brief Event which is called to broadcast information about left
-      /// mouse clicks on the scene.
+      /// mouse releases on the scene.
       /// For the 3D coordinates of that point on the scene, see
       /// `LeftClickToScene`.
       /// \sa LeftClickToScene
@@ -280,7 +280,7 @@ namespace ignition
       };
 
       /// \brief Event which is called to broadcast information about right
-      /// mouse clicks on the scene.
+      /// mouse releases on the scene.
       /// For the 3D coordinates of that point on the scene, see
       /// `RightClickToScene`.
       /// \sa RightClickToScene
@@ -329,8 +329,7 @@ namespace ignition
       class IGNITION_GUI_VISIBLE HoverOnScene : public QEvent
       {
         /// \brief Constructor
-        /// \param[in] _point The point at which the mouse is hovering within
-        /// the scene
+        /// \param[in] _mouse The hover mouse event on the scene
         public: explicit HoverOnScene(const common::MouseEvent &_mouse);
 
         /// \brief Unique type for this event.
@@ -385,6 +384,54 @@ namespace ignition
 
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 15);
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
+
+      /// \brief Event which is called to broadcast information about mouse
+      /// scrolls on the scene.
+      /// Includes the 3D coordinates of that point on the scene.
+      class IGNITION_GUI_VISIBLE ScrollOnScene : public QEvent
+      {
+        /// \brief Constructor
+        /// \param[in] _mouse The scroll mouse event on the scene
+        /// \param[in] _point 3D point being scrolled over.
+        public: explicit ScrollOnScene(
+          const common::MouseEvent &_mouse, const math::Vector3d &_point);
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 16);
+
+        /// \brief Return the left mouse event
+        public: const common::MouseEvent &Mouse() const;
+
+        /// \brief Get the point within the scene over which the user is
+        /// scrolling.
+        /// \return The 3D point
+        public: math::Vector3d Point() const;
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
+
+      /// \brief Event which is called to broadcast information about mouse
+      /// drags on the scene.
+      class IGNITION_GUI_VISIBLE DragOnScene : public QEvent
+      {
+        /// \brief Constructor
+        /// \param[in] _mouse The scroll mouse event on the scene
+        public: explicit DragOnScene(const common::MouseEvent &_mouse);
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 17);
+
+        /// \brief Get the point within the scene over which the user is
+        /// dragging.
+        /// \return The 2D point
+        public: common::MouseEvent Mouse() const;
 
         /// \internal
         /// \brief Private data pointer

--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -401,7 +401,7 @@ namespace ignition
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 16);
 
-        /// \brief Return the left mouse event
+        /// \brief Return the scroll mouse event
         public: const common::MouseEvent &Mouse() const;
 
         /// \internal
@@ -414,7 +414,7 @@ namespace ignition
       class IGNITION_GUI_VISIBLE DragOnScene : public QEvent
       {
         /// \brief Constructor
-        /// \param[in] _mouse The scroll mouse event on the scene
+        /// \param[in] _mouse The drag mouse event on the scene
         public: explicit DragOnScene(const common::MouseEvent &_mouse);
 
         /// \brief Unique type for this event.
@@ -442,7 +442,7 @@ namespace ignition
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 18);
 
-        /// \brief Return the right mouse event
+        /// \brief Return the button press mouse event
         public: const common::MouseEvent &Mouse() const;
 
         /// \internal

--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -392,25 +392,17 @@ namespace ignition
 
       /// \brief Event which is called to broadcast information about mouse
       /// scrolls on the scene.
-      /// Includes the 3D coordinates of that point on the scene.
       class IGNITION_GUI_VISIBLE ScrollOnScene : public QEvent
       {
         /// \brief Constructor
         /// \param[in] _mouse The scroll mouse event on the scene
-        /// \param[in] _point 3D point being scrolled over.
-        public: explicit ScrollOnScene(
-          const common::MouseEvent &_mouse, const math::Vector3d &_point);
+        public: explicit ScrollOnScene(const common::MouseEvent &_mouse);
 
         /// \brief Unique type for this event.
         static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 16);
 
         /// \brief Return the left mouse event
         public: const common::MouseEvent &Mouse() const;
-
-        /// \brief Get the point within the scene over which the user is
-        /// scrolling.
-        /// \return The 3D point
-        public: math::Vector3d Point() const;
 
         /// \internal
         /// \brief Private data pointer

--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -437,6 +437,26 @@ namespace ignition
         /// \brief Private data pointer
         IGN_UTILS_IMPL_PTR(dataPtr)
       };
+
+      /// \brief Event which is called to broadcast information about mouse
+      /// presses on the scene, with right, left or middle buttons.
+      class IGNITION_GUI_VISIBLE MousePressOnScene : public QEvent
+      {
+        /// \brief Constructor
+        /// \param[in] _mouse The mouse event on the scene
+        public: MousePressOnScene(
+          const common::MouseEvent &_mouse);
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 18);
+
+        /// \brief Return the right mouse event
+        public: const common::MouseEvent &Mouse() const;
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
     }
   }
 }

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -115,6 +115,43 @@ ignition::common::MouseEvent ignition::gui::convert(const QMouseEvent &_e)
 }
 
 //////////////////////////////////////////////////
+ignition::common::MouseEvent ignition::gui::convert(const QWheelEvent &_e)
+{
+  common::MouseEvent event;
+
+  event.SetType(common::MouseEvent::SCROLL);
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+  event.SetPos(_e.x(), _e.y());
+#else
+  event.SetPos(_e.position().x(), _e.position().y());
+#endif
+  double scroll = (_e.angleDelta().y() > 0) ? -1.0 : 1.0;
+  event.SetScroll(scroll, scroll);
+
+  // Buttons
+  if (_e.buttons() & Qt::LeftButton)
+    event.SetButtons(event.Buttons() | common::MouseEvent::LEFT);
+
+  if (_e.buttons() & Qt::RightButton)
+    event.SetButtons(event.Buttons() | common::MouseEvent::RIGHT);
+
+  if (_e.buttons() & Qt::MiddleButton)
+    event.SetButtons(event.Buttons() | common::MouseEvent::MIDDLE);
+
+  // Modifiers
+  if (_e.modifiers() & Qt::ShiftModifier)
+    event.SetShift(true);
+
+  if (_e.modifiers() & Qt::ControlModifier)
+    event.SetControl(true);
+
+  if (_e.modifiers() & Qt::AltModifier)
+    event.SetAlt(true);
+
+  return event;
+}
+
+//////////////////////////////////////////////////
 ignition::common::KeyEvent ignition::gui::convert(const QKeyEvent &_e)
 {
   common::KeyEvent event;

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -149,16 +149,22 @@ TEST(ConversionsTest, MouseEvent)
 
   // Scroll
   {
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
     QWheelEvent qtEvent(QPointF(123, 456), QPointF(1000, 2000), QPoint(2, 3),
-        QPoint(1, 4), Qt::LeftButton, Qt::ShiftModifier, Qt::ScrollUpdate,
-        true);
+        QPoint(1, 4), -1, Qt::Horizontal, Qt::MiddleButton, Qt::ShiftModifier,
+        Qt::ScrollUpdate, Qt::MouseEventNotSynthesized, false);
+#else
+    QWheelEvent qtEvent(QPointF(123, 456), QPointF(1000, 2000), QPoint(2, 3),
+        QPoint(1, 4), Qt::MiddleButton, Qt::ShiftModifier, Qt::ScrollUpdate,
+        false);
+#endif
 
     auto ignEvent = convert(qtEvent);
 
     EXPECT_EQ(ignEvent.Type(), common::MouseEvent::SCROLL);
     EXPECT_EQ(ignEvent.Pos(), math::Vector2i(123, 456));
     EXPECT_EQ(ignEvent.Scroll(), math::Vector2i(-1, -1));
-    EXPECT_EQ(ignEvent.Buttons(), common::MouseEvent::LEFT);
+    EXPECT_EQ(ignEvent.Buttons(), common::MouseEvent::MIDDLE);
     EXPECT_FALSE(ignEvent.Dragging());
     EXPECT_TRUE(ignEvent.Shift());
   }

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -146,6 +146,22 @@ TEST(ConversionsTest, MouseEvent)
     EXPECT_TRUE(ignEvent.Dragging());
     EXPECT_TRUE(ignEvent.Alt());
   }
+
+  // Scroll
+  {
+    QWheelEvent qtEvent(QPointF(123, 456), QPointF(1000, 2000), QPoint(2, 3),
+        QPoint(1, 4), Qt::LeftButton, Qt::ShiftModifier, Qt::ScrollUpdate,
+        true);
+
+    auto ignEvent = convert(qtEvent);
+
+    EXPECT_EQ(ignEvent.Type(), common::MouseEvent::SCROLL);
+    EXPECT_EQ(ignEvent.Pos(), math::Vector2i(123, 456));
+    EXPECT_EQ(ignEvent.Scroll(), math::Vector2i(-1, -1));
+    EXPECT_EQ(ignEvent.Buttons(), common::MouseEvent::LEFT);
+    EXPECT_FALSE(ignEvent.Dragging());
+    EXPECT_TRUE(ignEvent.Shift());
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -120,19 +120,19 @@ class ignition::gui::events::DropOnScene::Implementation
 
 class ignition::gui::events::ScrollOnScene::Implementation
 {
-  /// \brief Mouse event
+  /// \brief Mouse event with scroll information.
   public: common::MouseEvent mouse;
 };
 
 class ignition::gui::events::DragOnScene::Implementation
 {
-  /// \brief The 2D point over which the user is hovering.
+  /// \brief Mouse event with drag information.
   public: common::MouseEvent mouse;
 };
 
 class ignition::gui::events::MousePressOnScene::Implementation
 {
-  /// \brief Mouse event
+  /// \brief Mouse event with press information.
   public: common::MouseEvent mouse;
 };
 

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -133,6 +133,12 @@ class ignition::gui::events::DragOnScene::Implementation
   public: common::MouseEvent mouse;
 };
 
+class ignition::gui::events::MousePressOnScene::Implementation
+{
+  /// \brief Mouse event
+  public: common::MouseEvent mouse;
+};
+
 using namespace ignition;
 using namespace gui;
 using namespace events;
@@ -390,6 +396,19 @@ DragOnScene::DragOnScene(const common::MouseEvent &_mouse)
 
 /////////////////////////////////////////////////
 common::MouseEvent DragOnScene::Mouse() const
+{
+  return this->dataPtr->mouse;
+}
+
+/////////////////////////////////////////////////
+MousePressOnScene::MousePressOnScene(const common::MouseEvent &_mouse)
+    : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->mouse = _mouse;
+}
+
+/////////////////////////////////////////////////
+const common::MouseEvent &MousePressOnScene::Mouse() const
 {
   return this->dataPtr->mouse;
 }

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -118,6 +118,21 @@ class ignition::gui::events::DropOnScene::Implementation
   public: ignition::math::Vector2i mouse;
 };
 
+class ignition::gui::events::ScrollOnScene::Implementation
+{
+  /// \brief Mouse event
+  public: common::MouseEvent mouse;
+
+  /// \brief The 3D point that the user scrolled within the scene.
+  public: math::Vector3d point;
+};
+
+class ignition::gui::events::DragOnScene::Implementation
+{
+  /// \brief The 2D point over which the user is hovering.
+  public: common::MouseEvent mouse;
+};
+
 using namespace ignition;
 using namespace gui;
 using namespace events;
@@ -341,6 +356,40 @@ const std::string &DropOnScene::DropText() const
 
 /////////////////////////////////////////////////
 const ignition::math::Vector2i &DropOnScene::Mouse() const
+{
+  return this->dataPtr->mouse;
+}
+
+/////////////////////////////////////////////////
+ScrollOnScene::ScrollOnScene(const common::MouseEvent &_mouse,
+    const math::Vector3d &_point)
+    : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->mouse = _mouse;
+  this->dataPtr->point = _point;
+}
+
+/////////////////////////////////////////////////
+const common::MouseEvent &ScrollOnScene::Mouse() const
+{
+  return this->dataPtr->mouse;
+}
+
+/////////////////////////////////////////////////
+math::Vector3d ScrollOnScene::Point() const
+{
+  return this->dataPtr->point;
+}
+
+/////////////////////////////////////////////////
+DragOnScene::DragOnScene(const common::MouseEvent &_mouse)
+    : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->mouse = _mouse;
+}
+
+/////////////////////////////////////////////////
+common::MouseEvent DragOnScene::Mouse() const
 {
   return this->dataPtr->mouse;
 }

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -122,9 +122,6 @@ class ignition::gui::events::ScrollOnScene::Implementation
 {
   /// \brief Mouse event
   public: common::MouseEvent mouse;
-
-  /// \brief The 3D point that the user scrolled within the scene.
-  public: math::Vector3d point;
 };
 
 class ignition::gui::events::DragOnScene::Implementation
@@ -367,24 +364,16 @@ const ignition::math::Vector2i &DropOnScene::Mouse() const
 }
 
 /////////////////////////////////////////////////
-ScrollOnScene::ScrollOnScene(const common::MouseEvent &_mouse,
-    const math::Vector3d &_point)
+ScrollOnScene::ScrollOnScene(const common::MouseEvent &_mouse)
     : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
 {
   this->dataPtr->mouse = _mouse;
-  this->dataPtr->point = _point;
 }
 
 /////////////////////////////////////////////////
 const common::MouseEvent &ScrollOnScene::Mouse() const
 {
   return this->dataPtr->mouse;
-}
-
-/////////////////////////////////////////////////
-math::Vector3d ScrollOnScene::Point() const
-{
-  return this->dataPtr->point;
 }
 
 /////////////////////////////////////////////////

--- a/src/GuiEvents_TEST.cc
+++ b/src/GuiEvents_TEST.cc
@@ -212,3 +212,17 @@ TEST(GuiEventsTest, DropOnScene)
   EXPECT_EQ(ignition::math::Vector2i(3, 100), dropOnScene.Mouse());
   EXPECT_EQ("text", dropOnScene.DropText());
 }
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, MousePressOnScene)
+{
+  ignition::common::MouseEvent mouse;
+  mouse.SetControl(true);
+  mouse.SetAlt(true);
+  events::MousePressOnScene event(mouse);
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_TRUE(event.Mouse().Control());
+  EXPECT_TRUE(event.Mouse().Alt());
+  EXPECT_FALSE(event.Mouse().Shift());
+}

--- a/src/GuiEvents_TEST.cc
+++ b/src/GuiEvents_TEST.cc
@@ -204,6 +204,20 @@ TEST(GuiEventsTest, SpawnCloneFromName)
 }
 
 /////////////////////////////////////////////////
+TEST(GuiEventsTest, ScrollOnScene)
+{
+  ignition::common::MouseEvent mouse;
+  mouse.SetControl(true);
+  mouse.SetAlt(true);
+  events::ScrollOnScene event(mouse);
+
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_TRUE(event.Mouse().Control());
+  EXPECT_TRUE(event.Mouse().Alt());
+  EXPECT_FALSE(event.Mouse().Shift());
+}
+
+/////////////////////////////////////////////////
 TEST(GuiEventsTest, DropOnScene)
 {
   events::DropOnScene dropOnScene("text", ignition::math::Vector2i(3, 100));

--- a/src/GuiEvents_TEST.cc
+++ b/src/GuiEvents_TEST.cc
@@ -204,6 +204,16 @@ TEST(GuiEventsTest, SpawnCloneFromName)
 }
 
 /////////////////////////////////////////////////
+TEST(GuiEventsTest, DropOnScene)
+{
+  events::DropOnScene dropOnScene("text", ignition::math::Vector2i(3, 100));
+
+  EXPECT_LT(QEvent::User, dropOnScene.type());
+  EXPECT_EQ(ignition::math::Vector2i(3, 100), dropOnScene.Mouse());
+  EXPECT_EQ("text", dropOnScene.DropText());
+}
+
+/////////////////////////////////////////////////
 TEST(GuiEventsTest, ScrollOnScene)
 {
   ignition::common::MouseEvent mouse;
@@ -218,13 +228,17 @@ TEST(GuiEventsTest, ScrollOnScene)
 }
 
 /////////////////////////////////////////////////
-TEST(GuiEventsTest, DropOnScene)
+TEST(GuiEventsTest, DragOnScene)
 {
-  events::DropOnScene dropOnScene("text", ignition::math::Vector2i(3, 100));
+  ignition::common::MouseEvent mouse;
+  mouse.SetControl(true);
+  mouse.SetAlt(true);
+  events::DragOnScene event(mouse);
 
-  EXPECT_LT(QEvent::User, dropOnScene.type());
-  EXPECT_EQ(ignition::math::Vector2i(3, 100), dropOnScene.Mouse());
-  EXPECT_EQ("text", dropOnScene.DropText());
+  EXPECT_LT(QEvent::User, event.type());
+  EXPECT_TRUE(event.Mouse().Control());
+  EXPECT_TRUE(event.Mouse().Alt());
+  EXPECT_FALSE(event.Mouse().Shift());
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -184,15 +184,14 @@ void InteractiveViewControlPrivate::OnRender()
     double amount = -this->drag.Y() * distance / 5.0;
     this->viewControl->Zoom(amount);
   }
+  else if (this->mouseEvent.Type() == common::MouseEvent::PRESS)
+  {
+    this->target = rendering::screenToScene(
+      this->mouseEvent.PressPos(), this->camera, this->rayQuery);
+    this->viewControl->SetTarget(this->target);
+  }
   else
   {
-    if (this->drag == math::Vector2d::Zero)
-    {
-      this->target = rendering::screenToScene(
-        this->mouseEvent.PressPos(), this->camera, this->rayQuery);
-      this->viewControl->SetTarget(this->target);
-    }
-
     // Pan with left button
     if (this->mouseEvent.Buttons() & common::MouseEvent::LEFT)
     {
@@ -286,6 +285,15 @@ bool InteractiveViewControl::eventFilter(QObject *_obj, QEvent *_event)
     this->dataPtr->drag = math::Vector2d::Zero;
     this->dataPtr->mouseEvent = leftClickOnScene->Mouse();
   }
+  else if (_event->type() == events::MousePressOnScene::kType)
+  {
+    auto pressOnScene =
+      reinterpret_cast<ignition::gui::events::MousePressOnScene *>(_event);
+    this->dataPtr->mouseDirty = true;
+
+    this->dataPtr->drag = math::Vector2d::Zero;
+    this->dataPtr->mouseEvent = pressOnScene->Mouse();
+  }
   else if (_event->type() == events::DragOnScene::kType)
   {
     auto dragOnScene =
@@ -293,14 +301,8 @@ bool InteractiveViewControl::eventFilter(QObject *_obj, QEvent *_event)
     this->dataPtr->mouseDirty = true;
 
     auto dragStart = this->dataPtr->mouseEvent.Pos();
-//    // Just started dragging, compare to event's press pos
-//    if (this->dataPtr->drag == math::Vector2d::Zero)
-//    {
-//      dragStart = dragOnScene->Mouse().PressPos();
-//    }
     auto dragInt = dragOnScene->Mouse().Pos() - dragStart;
     auto dragDistance = math::Vector2d(dragInt.X(), dragInt.Y());
-
 
     this->dataPtr->drag += dragDistance;
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -467,9 +467,7 @@ void IgnRenderer::BroadcastScroll()
   if (this->dataPtr->mouseEvent.Type() != common::MouseEvent::SCROLL)
     return;
 
-  auto pos = this->ScreenToScene(this->dataPtr->mouseEvent.Pos());
-
-  events::ScrollOnScene scrollOnSceneEvent(this->dataPtr->mouseEvent, pos);
+  events::ScrollOnScene scrollOnSceneEvent(this->dataPtr->mouseEvent);
   App()->sendEvent(App()->findChild<MainWindow *>(), &scrollOnSceneEvent);
 
   this->dataPtr->mouseDirty = false;

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -319,6 +319,7 @@ void IgnRenderer::HandleMouseEvent()
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   this->BroadcastHoverPos();
   this->BroadcastDrag();
+  this->BroadcastMousePress();
   this->BroadcastLeftClick();
   this->BroadcastRightClick();
   this->BroadcastScroll();
@@ -367,11 +368,6 @@ void IgnRenderer::BroadcastDrop()
 void IgnRenderer::BroadcastHoverPos()
 {
   if (!this->dataPtr->hoverDirty)
-    return;
-
-  // Only broadcast hover if not dragging
-  // FIXME mixing mouseEvent with hoverEvent
-  if (this->dataPtr->mouseEvent.Dragging())
     return;
 
   auto pos = this->ScreenToScene(this->dataPtr->mouseHoverPos);
@@ -443,6 +439,21 @@ void IgnRenderer::BroadcastRightClick()
 
   events::RightClickOnScene rightClickOnSceneEvent(this->dataPtr->mouseEvent);
   App()->sendEvent(App()->findChild<MainWindow *>(), &rightClickOnSceneEvent);
+
+  this->dataPtr->mouseDirty = false;
+}
+
+/////////////////////////////////////////////////
+void IgnRenderer::BroadcastMousePress()
+{
+  if (!this->dataPtr->mouseDirty)
+    return;
+
+  if (this->dataPtr->mouseEvent.Type() != common::MouseEvent::PRESS)
+    return;
+
+  events::MousePressOnScene event(this->dataPtr->mouseEvent);
+  App()->sendEvent(App()->findChild<MainWindow *>(), &event);
 
   this->dataPtr->mouseDirty = false;
 }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -488,7 +488,7 @@ void IgnRenderer::BroadcastKeyRelease()
 /////////////////////////////////////////////////
 void IgnRenderer::BroadcastKeyPress()
 {
-  if (this->dataPtr->keyEvent.Type() == common::KeyEvent::PRESS)
+  if (this->dataPtr->keyEvent.Type() != common::KeyEvent::PRESS)
     return;
 
   events::KeyPressOnScene keyPress(this->dataPtr->keyEvent);

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -318,27 +318,14 @@ void IgnRenderer::HandleMouseEvent()
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   this->BroadcastHoverPos();
+  this->BroadcastDrag();
   this->BroadcastLeftClick();
   this->BroadcastRightClick();
+  this->BroadcastScroll();
   this->BroadcastKeyPress();
   this->BroadcastKeyRelease();
   this->BroadcastDrop();
-  this->HandleMouseViewControl();
   this->dataPtr->mouseDirty = false;
-}
-
-/////////////////////////////////////////////////
-void IgnRenderer::HandleMouseViewControl()
-{
-  if (!this->dataPtr->mouseDirty)
-    return;
-
-  auto pos = this->ScreenToScene(this->dataPtr->mouseEvent.Pos());
-
-  events::LeftClickOnScene leftClickOnSceneEvent(this->dataPtr->mouseEvent);
-  events::LeftClickToScene leftClickToSceneEvent(pos);
-  App()->sendEvent(App()->findChild<MainWindow *>(), &leftClickOnSceneEvent);
-  App()->sendEvent(App()->findChild<MainWindow *>(), &leftClickToSceneEvent);
 }
 
 ////////////////////////////////////////////////
@@ -382,6 +369,11 @@ void IgnRenderer::BroadcastHoverPos()
   if (!this->dataPtr->hoverDirty)
     return;
 
+  // Only broadcast hover if not dragging
+  // FIXME mixing mouseEvent with hoverEvent
+  if (this->dataPtr->mouseEvent.Dragging())
+    return;
+
   auto pos = this->ScreenToScene(this->dataPtr->mouseHoverPos);
 
   events::HoverToScene hoverToSceneEvent(pos);
@@ -393,15 +385,30 @@ void IgnRenderer::BroadcastHoverPos()
   hoverMouseEvent.SetType(common::MouseEvent::MOVE);
   events::HoverOnScene hoverOnSceneEvent(hoverMouseEvent);
   App()->sendEvent(App()->findChild<MainWindow *>(), &hoverOnSceneEvent);
+
+  this->dataPtr->hoverDirty = false;
+}
+
+/////////////////////////////////////////////////
+void IgnRenderer::BroadcastDrag()
+{
+  if (!this->dataPtr->mouseDirty)
+    return;
+
+  // Only broadcast drag if dragging
+  if (!this->dataPtr->mouseEvent.Dragging())
+    return;
+
+  events::DragOnScene dragEvent(this->dataPtr->mouseEvent);
+  App()->sendEvent(App()->findChild<MainWindow *>(), &dragEvent);
+
+  this->dataPtr->mouseDirty = false;
 }
 
 /////////////////////////////////////////////////
 void IgnRenderer::BroadcastLeftClick()
 {
   if (!this->dataPtr->mouseDirty)
-    return;
-
-  if (this->dataPtr->mouseEvent.Dragging())
     return;
 
   if (this->dataPtr->mouseEvent.Button() != common::MouseEvent::LEFT ||
@@ -412,15 +419,17 @@ void IgnRenderer::BroadcastLeftClick()
 
   events::LeftClickToScene leftClickToSceneEvent(pos);
   App()->sendEvent(App()->findChild<MainWindow *>(), &leftClickToSceneEvent);
+
+  events::LeftClickOnScene leftClickOnSceneEvent(this->dataPtr->mouseEvent);
+  App()->sendEvent(App()->findChild<MainWindow *>(), &leftClickOnSceneEvent);
+
+  this->dataPtr->mouseDirty = false;
 }
 
 /////////////////////////////////////////////////
 void IgnRenderer::BroadcastRightClick()
 {
   if (!this->dataPtr->mouseDirty)
-    return;
-
-  if (this->dataPtr->mouseEvent.Dragging())
     return;
 
   if (this->dataPtr->mouseEvent.Button() != common::MouseEvent::RIGHT ||
@@ -431,31 +440,52 @@ void IgnRenderer::BroadcastRightClick()
 
   events::RightClickToScene rightClickToSceneEvent(pos);
   App()->sendEvent(App()->findChild<MainWindow *>(), &rightClickToSceneEvent);
+
   events::RightClickOnScene rightClickOnSceneEvent(this->dataPtr->mouseEvent);
   App()->sendEvent(App()->findChild<MainWindow *>(), &rightClickOnSceneEvent);
+
+  this->dataPtr->mouseDirty = false;
 }
 
+/////////////////////////////////////////////////
+void IgnRenderer::BroadcastScroll()
+{
+  if (!this->dataPtr->mouseDirty)
+    return;
+
+  if (this->dataPtr->mouseEvent.Type() != common::MouseEvent::SCROLL)
+    return;
+
+  auto pos = this->ScreenToScene(this->dataPtr->mouseEvent.Pos());
+
+  events::ScrollOnScene scrollOnSceneEvent(this->dataPtr->mouseEvent, pos);
+  App()->sendEvent(App()->findChild<MainWindow *>(), &scrollOnSceneEvent);
+
+  this->dataPtr->mouseDirty = false;
+}
 
 /////////////////////////////////////////////////
 void IgnRenderer::BroadcastKeyRelease()
 {
-  if (this->dataPtr->keyEvent.Type() == common::KeyEvent::RELEASE)
-  {
-    events::KeyReleaseOnScene keyRelease(this->dataPtr->keyEvent);
-    App()->sendEvent(App()->findChild<MainWindow *>(), &keyRelease);
-    this->dataPtr->keyEvent.SetType(common::KeyEvent::NO_EVENT);
-  }
+  if (this->dataPtr->keyEvent.Type() != common::KeyEvent::RELEASE)
+    return;
+
+  events::KeyReleaseOnScene keyRelease(this->dataPtr->keyEvent);
+  App()->sendEvent(App()->findChild<MainWindow *>(), &keyRelease);
+
+  this->dataPtr->keyEvent.SetType(common::KeyEvent::NO_EVENT);
 }
 
 /////////////////////////////////////////////////
 void IgnRenderer::BroadcastKeyPress()
 {
   if (this->dataPtr->keyEvent.Type() == common::KeyEvent::PRESS)
-  {
-    events::KeyPressOnScene keyPress(this->dataPtr->keyEvent);
-    App()->sendEvent(App()->findChild<MainWindow *>(), &keyPress);
-    this->dataPtr->keyEvent.SetType(common::KeyEvent::NO_EVENT);
-  }
+    return;
+
+  events::KeyPressOnScene keyPress(this->dataPtr->keyEvent);
+  App()->sendEvent(App()->findChild<MainWindow *>(), &keyPress);
+
+  this->dataPtr->keyEvent.SetType(common::KeyEvent::NO_EVENT);
 }
 
 /////////////////////////////////////////////////
@@ -1053,9 +1083,8 @@ void RenderWindowItem::OnDropped(const QString &_drop,
 /////////////////////////////////////////////////
 void RenderWindowItem::mousePressEvent(QMouseEvent *_e)
 {
-  auto pressPos = this->dataPtr->mouseEvent.PressPos();
   this->dataPtr->mouseEvent = convert(*_e);
-  this->dataPtr->mouseEvent.SetPressPos(pressPos);
+  this->dataPtr->mouseEvent.SetPressPos(this->dataPtr->mouseEvent.Pos());
 
   this->dataPtr->renderThread->ignRenderer.NewMouseEvent(
       this->dataPtr->mouseEvent);
@@ -1084,8 +1113,13 @@ void RenderWindowItem::keyReleaseEvent(QKeyEvent *_e)
 ////////////////////////////////////////////////
 void RenderWindowItem::mouseReleaseEvent(QMouseEvent *_e)
 {
+  // Store values that depend on previous events
+  auto pressPos = this->dataPtr->mouseEvent.PressPos();
+  auto dragging = this->dataPtr->mouseEvent.Dragging();
+
   this->dataPtr->mouseEvent = convert(*_e);
-  this->dataPtr->mouseEvent.SetPressPos(_e->pos().x(), _e->pos().y());
+  this->dataPtr->mouseEvent.SetPressPos(pressPos);
+  this->dataPtr->mouseEvent.SetDragging(dragging);
 
   this->dataPtr->renderThread->ignRenderer.NewMouseEvent(
       this->dataPtr->mouseEvent);
@@ -1094,29 +1128,26 @@ void RenderWindowItem::mouseReleaseEvent(QMouseEvent *_e)
 ////////////////////////////////////////////////
 void RenderWindowItem::mouseMoveEvent(QMouseEvent *_e)
 {
-  auto event = convert(*_e);
-  event.SetPressPos(this->dataPtr->mouseEvent.PressPos());
+  // Store values that depend on previous events
+  auto pressPos = this->dataPtr->mouseEvent.PressPos();
 
-  if (!event.Dragging())
-    return;
+  this->dataPtr->mouseEvent = convert(*_e);
 
-  this->dataPtr->renderThread->ignRenderer.NewMouseEvent(event);
-  this->dataPtr->mouseEvent = event;
+  if (this->dataPtr->mouseEvent.Dragging())
+    this->dataPtr->mouseEvent.SetPressPos(pressPos);
+
+  this->dataPtr->renderThread->ignRenderer.NewMouseEvent(
+      this->dataPtr->mouseEvent);
 }
 
 ////////////////////////////////////////////////
 void RenderWindowItem::wheelEvent(QWheelEvent *_e)
 {
-  this->dataPtr->mouseEvent.SetType(common::MouseEvent::SCROLL);
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-  this->dataPtr->mouseEvent.SetPos(_e->x(), _e->y());
-#else
-  this->dataPtr->mouseEvent.SetPos(_e->position().x(), _e->position().y());
-#endif
-  double scroll = (_e->angleDelta().y() > 0) ? -1.0 : 1.0;
+  this->forceActiveFocus();
+
+  this->dataPtr->mouseEvent = convert(*_e);
   this->dataPtr->renderThread->ignRenderer.NewMouseEvent(
     this->dataPtr->mouseEvent);
-  this->dataPtr->mouseEvent.SetScroll(scroll, scroll);
 }
 
 ////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -139,11 +139,14 @@ namespace plugins
     /// \brief Broadcasts drag events.
     private: void BroadcastDrag();
 
-    /// \brief Broadcasts a left click within the scene
+    /// \brief Broadcasts a left click (release) within the scene
     private: void BroadcastLeftClick();
 
-    /// \brief Broadcasts a right click within the scene
+    /// \brief Broadcasts a right click (release) within the scene
     private: void BroadcastRightClick();
+
+    /// \brief Broadcasts a mouse press within the scene
+    private: void BroadcastMousePress();
 
     /// \brief Broadcasts a scroll event within the scene.
     private: void BroadcastScroll();

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -133,17 +133,20 @@ namespace plugins
     /// \brief Handle mouse event for view control
     private: void HandleMouseEvent();
 
-    /// \brief Handle mouse event for view control
-    private: void HandleMouseViewControl();
-
     /// \brief Broadcasts the currently hovered 3d scene location.
     private: void BroadcastHoverPos();
+
+    /// \brief Broadcasts drag events.
+    private: void BroadcastDrag();
 
     /// \brief Broadcasts a left click within the scene
     private: void BroadcastLeftClick();
 
     /// \brief Broadcasts a right click within the scene
     private: void BroadcastRightClick();
+
+    /// \brief Broadcasts a scroll event within the scene.
+    private: void BroadcastScroll();
 
     /// \brief Broadcasts a key release event within the scene
     private: void BroadcastKeyRelease();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #293

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

I started working on the issues pointed out on #293 and ran into various other issues and inconsistencies about the way we're handling mouse events. Currently there are scrolls and drags being sent as left clicks, both mouse presses and releases broadcasted as clicks... ~~I'm still sorting it out, hopefully will be done in time for the release.~~

Summary of changes:

* Add 3 new events: drag, scroll and press
* Press with any button is used to pick the orbit target
* Drag information was previously being acquired from a combination of the previous event and a left click. Now it's passed through the drag event.
* I think scroll info was also coming from other events, but now it's its own event
* The `HandleMouseViewControl` was a confusing function that re-sent the left clicks, so I removed it

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
