### PR TITLE
Fix mimimal scene deadlock on shutdown

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -809,7 +809,7 @@ RenderWindowItem::RenderWindowItem(QQuickItem *_parent)
 RenderWindowItem::~RenderWindowItem()
 {
   // Disconnect our QT connections.
-  for(auto conn: this->dataPtr->connections)
+  for(auto conn : this->dataPtr->connections)
     QObject::disconnect(conn);
 
   this->dataPtr->renderSync.Shutdown();


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/1084

## Summary

The GUI would occasionally hang on shutdown. The problem was that the QT connections are still active during the shutdown process, which could trigger the "WaitForWorker" function after the `renderSync` object has been destroyed. This in turn causes the condition variable to lock on a `wait`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**