### PR TITLE
Set near/far camera clipping distance

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -542,6 +542,8 @@ void IgnRenderer::Initialize()
   this->dataPtr->camera->SetUserData("user-camera", true);
   root->AddChild(this->dataPtr->camera);
   this->dataPtr->camera->SetLocalPose(this->cameraPose);
+  this->dataPtr->camera->SetNearClipPlane(this->cameraNearClip);
+  this->dataPtr->camera->SetFarClipPlane(this->cameraFarClip);
   this->dataPtr->camera->SetImageWidth(this->textureSize.width());
   this->dataPtr->camera->SetImageHeight(this->textureSize.height());
   this->dataPtr->camera->SetAntiAliasing(8);
@@ -945,6 +947,18 @@ void RenderWindowItem::SetCameraPose(const math::Pose3d &_pose)
 }
 
 /////////////////////////////////////////////////
+void RenderWindowItem::SetCameraNearClip(const double &_near)
+{
+  this->dataPtr->renderThread->ignRenderer.cameraNearClip = _near;
+}
+
+/////////////////////////////////////////////////
+void RenderWindowItem::SetCameraFarClip(const double &_far)
+{
+  this->dataPtr->renderThread->ignRenderer.cameraFarClip = _far;
+}
+
+/////////////////////////////////////////////////
 void RenderWindowItem::SetSceneService(const std::string &_service)
 {
   this->dataPtr->renderThread->ignRenderer.sceneService = _service;
@@ -1042,6 +1056,44 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       poseStr << std::string(elem->GetText());
       poseStr >> pose;
       renderWindow->SetCameraPose(pose);
+    }
+
+    elem = _pluginElem->FirstChildElement("camera_clip");
+    if (nullptr != elem && !elem->NoChildren())
+    {
+      auto child = elem->FirstChildElement("near");
+      if (nullptr != child && nullptr != child->GetText())
+      {
+        double near;
+        std::stringstream nearStr;
+        nearStr << std::string(child->GetText());
+        if (nearStr >> near)
+        {
+          renderWindow->SetCameraNearClip(near);
+        }
+        else
+        {
+          ignerr << "Unable to set <near> to '" << nearStr.str()
+                 << "' using default near clip distance" << std::endl;
+        }
+      }
+
+      child = elem->FirstChildElement("far");
+      if (nullptr != child && nullptr != child->GetText())
+      {
+        double far;
+        std::stringstream farStr;
+        farStr << std::string(child->GetText());
+        if (farStr >> far)
+        {
+          renderWindow->SetCameraFarClip(far);
+        }
+        else
+        {
+          ignerr << "Unable to set <far> to '" << farStr.str()
+                 << "' using default far clip distance" << std::endl;
+        }
+      }
     }
 
     elem = _pluginElem->FirstChildElement("service");

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -947,13 +947,13 @@ void RenderWindowItem::SetCameraPose(const math::Pose3d &_pose)
 }
 
 /////////////////////////////////////////////////
-void RenderWindowItem::SetCameraNearClip(const double &_near)
+void RenderWindowItem::SetCameraNearClip(double _near)
 {
   this->dataPtr->renderThread->ignRenderer.cameraNearClip = _near;
 }
 
 /////////////////////////////////////////////////
-void RenderWindowItem::SetCameraFarClip(const double &_far)
+void RenderWindowItem::SetCameraFarClip(double _far)
 {
   this->dataPtr->renderThread->ignRenderer.cameraFarClip = _far;
 }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1064,10 +1064,10 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       auto child = elem->FirstChildElement("near");
       if (nullptr != child && nullptr != child->GetText())
       {
-        double near;
+        double n;
         std::stringstream nearStr;
         nearStr << std::string(child->GetText());
-        nearStr >> near;
+        nearStr >> n;
         if (nearStr.fail())
         {
           ignerr << "Unable to set <near> to '" << nearStr.str()
@@ -1075,17 +1075,17 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         }
         else
         {
-          renderWindow->SetCameraNearClip(near);
+          renderWindow->SetCameraNearClip(n);
         }
       }
 
       child = elem->FirstChildElement("far");
       if (nullptr != child && nullptr != child->GetText())
       {
-        double far;
+        double f;
         std::stringstream farStr;
         farStr << std::string(child->GetText());
-        farStr >> far;
+        farStr >> f;
         if (farStr.fail())
         {
           ignerr << "Unable to set <far> to '" << farStr.str()
@@ -1093,7 +1093,7 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         }
         else
         {
-          renderWindow->SetCameraFarClip(far);
+          renderWindow->SetCameraFarClip(f);
         }
       }
     }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1067,14 +1067,15 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         double near;
         std::stringstream nearStr;
         nearStr << std::string(child->GetText());
-        if (nearStr >> near)
-        {
-          renderWindow->SetCameraNearClip(near);
-        }
-        else
+        nearStr >> near;
+        if (nearStr.fail())
         {
           ignerr << "Unable to set <near> to '" << nearStr.str()
                  << "' using default near clip distance" << std::endl;
+        }
+        else
+        {
+          renderWindow->SetCameraNearClip(near);
         }
       }
 
@@ -1084,14 +1085,15 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         double far;
         std::stringstream farStr;
         farStr << std::string(child->GetText());
-        if (farStr >> far)
-        {
-          renderWindow->SetCameraFarClip(far);
-        }
-        else
+        farStr >> far;
+        if (farStr.fail())
         {
           ignerr << "Unable to set <far> to '" << farStr.str()
                  << "' using default far clip distance" << std::endl;
+        }
+        else
+        {
+          renderWindow->SetCameraFarClip(far);
         }
       }
     }

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -297,11 +297,11 @@ namespace plugins
 
     /// \brief Set the render window camera's near clipping plane distance
     /// \param[in] _near Near clipping plane distance
-    public: void SetCameraNearClip(const double &_near);
+    public: void SetCameraNearClip(double _near);
 
     /// \brief Set the render window camera's far clipping plane distance
     /// \param[in] _far Far clipping plane distance
-    public: void SetCameraFarClip(const double &_far);
+    public: void SetCameraFarClip(double _far);
 
     /// \brief Set scene service to use in this render window
     /// A service call will be made using ign-transport to get scene

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -52,6 +52,9 @@ namespace plugins
   ///                          (0.3, 0.3, 0.3, 1.0)
   /// * \<camera_pose\> : Optional starting pose for the camera, defaults to
   ///                     (0, 0, 5, 0, 0, 0)
+  /// * \<camera_clip\> : Optional near/far clipping distance for camera
+  ///     * \<near\> : Camera's near clipping plane distance, defaults to 0.01
+  ///     * \<far\> : Camera's far clipping plane distance, defaults to 1000.0
   /// * \<sky\> : If present, sky is enabled.
   class MinimalScene : public Plugin
   {
@@ -181,6 +184,12 @@ namespace plugins
     /// \brief Initial Camera pose
     public: math::Pose3d cameraPose = math::Pose3d(0, 0, 2, 0, 0.4, 0);
 
+    /// \brief Default camera near clipping plane distance
+    public: double cameraNearClip = 0.01;
+
+    /// \brief Default camera far clipping plane distance
+    public: double cameraFarClip = 1000.0;
+
     /// \brief Scene background color
     public: math::Color backgroundColor = math::Color::Black;
 
@@ -283,8 +292,16 @@ namespace plugins
     public: void SetSceneName(const std::string &_name);
 
     /// \brief Set the initial pose the render window camera
-    /// \param[in] _pose Initical camera pose
+    /// \param[in] _pose Initial camera pose
     public: void SetCameraPose(const math::Pose3d &_pose);
+
+    /// \brief Set the render window camera's near clipping plane distance
+    /// \param[in] _near Near clipping plane distance
+    public: void SetCameraNearClip(const double &_near);
+
+    /// \brief Set the render window camera's far clipping plane distance
+    /// \param[in] _far Far clipping plane distance
+    public: void SetCameraFarClip(const double &_far);
 
     /// \brief Set scene service to use in this render window
     /// A service call will be made using ign-transport to get scene

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -82,6 +82,10 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
       "<ambient_light>1.0 0 0</ambient_light>"
       "<background_color>0 1 0</background_color>"
       "<camera_pose>1 2 3 0 0 1.57</camera_pose>"
+      "<camera_clip>"
+      "  <near>0.1</near>"
+      "  <far>5000</far>"
+      "/<camera_clip>"
     "</plugin>";
 
   tinyxml2::XMLDocument pluginDoc;
@@ -126,6 +130,8 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   ASSERT_NE(nullptr, camera);
 
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 1.57), camera->WorldPose());
+  EXPECT_DOUBLE_EQ(0.1, camera->NearClipPlane());
+  EXPECT_DOUBLE_EQ(5000.0, camera->FarClipPlane());
 
   // Cleanup
   auto plugins = win->findChildren<Plugin *>();
@@ -139,4 +145,3 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   engine->DestroyScene(scene);
   EXPECT_TRUE(rendering::unloadEngine(engine->Name()));
 }
-

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -85,7 +85,7 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
       "<camera_clip>"
       "  <near>0.1</near>"
       "  <far>5000</far>"
-      "/<camera_clip>"
+      "</camera_clip>"
     "</plugin>";
 
   tinyxml2::XMLDocument pluginDoc;


### PR DESCRIPTION
# 🎉 New feature

Closes #308

## Summary
Added ability to configure the user camera's near/far clipping distance in the `MinimalScene` plugin from xml. If none is set, the default near `0.01` and far `1000` is used.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
Add `<camera_clip>` to the `MinimalScene` plugin config. For example,
```xml
<camera_clip>
  <near>0.1</near>
  <far>5000</far>
</camera_clip>
```

to [minimal_scene.sdf](https://github.com/ignitionrobotics/ign-gazebo/blob/35ec2a75f6d0522bb840e0b704768864cfeb4ec4/examples/worlds/minimal_scene.sdf#L30-L42)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**