### PR TITLE
Prepare for 6.1.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui6 VERSION 6.0.0)
+project(ignition-gui6 VERSION 6.1.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,21 @@
 ## Ignition Gui 6
 
-### Ignition Gui 6.X.X
+### Ignition Gui 6.1.0 (2021-11-05)
+
+1. Improved doxygen
+    * [Pull request #275](https://github.com/ignitionrobotics/ign-gui/pull/275)
+
+1. Fix mimimal scene deadlock on shutdown
+    * [Pull request #300](https://github.com/ignitionrobotics/ign-gui/pull/300)
+
+1. Fix memory leak
+    * [Pull request #287](https://github.com/ignitionrobotics/ign-gui/pull/287)
+
+1. Set near/far camera clipping distance
+    * [Pull request #309](https://github.com/ignitionrobotics/ign-gui/pull/309)
+
+1. Support emitting an event on play/pause/step
+    * [Pull request #306](https://github.com/ignitionrobotics/ign-gui/pull/306)
 
 ### Ignition Gui 6.0.0 (2021-09-XX)
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 6.1.0 release.

Comparison to 6.1.0: https://github.com/ignitionrobotics/ign-gui/compare/ignition-gui6_6.0.0...ign-gui6

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/ignitionrobotics/ign-gazebo/pull/1109

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge**
