### PR TITLE
Don't crash if a plugin has invalid QML

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -387,6 +387,9 @@ bool Application::LoadPlugin(const std::string &_filename,
   else
     plugin->Load(_pluginElem);
 
+  if (nullptr == plugin->CardItem())
+    return false;
+
   // Store plugin in queue to be added to the window
   this->dataPtr->pluginsToAdd.push(plugin);
 

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -136,6 +136,14 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugin))
 
     EXPECT_FALSE(app.LoadPlugin("TestNotRegisteredPlugin"));
   }
+
+  // Plugin with invalid QML
+  {
+    Application app(g_argc, g_argv);
+    app.AddPluginPath(std::string(PROJECT_BINARY_PATH) + "/lib");
+
+    EXPECT_FALSE(app.LoadPlugin("TestInvalidQmlPlugin"));
+  }
 }
 
 //////////////////////////////////////////////////

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -11,6 +11,7 @@ link_directories(
 
 set (plugins
   TestBadInheritancePlugin
+  TestInvalidQmlPlugin
   TestNotRegisteredPlugin
   TestPlugin
 )

--- a/test/plugins/TestInvalidQmlPlugin.cc
+++ b/test/plugins/TestInvalidQmlPlugin.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/plugin/Register.hh>
+
+#include "TestInvalidQmlPlugin.hh"
+
+using namespace ignition;
+using namespace gui;
+
+/////////////////////////////////////////////////
+TestInvalidQmlPlugin::TestInvalidQmlPlugin()
+  : Plugin()
+{
+}
+
+/////////////////////////////////////////////////
+TestInvalidQmlPlugin::~TestInvalidQmlPlugin()
+{
+}
+
+// Register this plugin
+IGNITION_ADD_PLUGIN(ignition::gui::TestInvalidQmlPlugin,
+                    ignition::gui::Plugin)

--- a/test/plugins/TestInvalidQmlPlugin.hh
+++ b/test/plugins/TestInvalidQmlPlugin.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_GUI_TEST_MALFORMEDPLUGIN_HH_
+#define IGNITION_GUI_TEST_MALFORMEDPLUGIN_HH_
+
+#include <ignition/gui/Plugin.hh>
+
+namespace ignition
+{
+  namespace gui
+  {
+    class TestInvalidQmlPlugin : public Plugin
+    {
+      Q_OBJECT
+
+      /// \brief Constructor
+      public: TestInvalidQmlPlugin();
+
+      /// \brief Destructor
+      public: virtual ~TestInvalidQmlPlugin();
+    };
+  }
+}
+
+#endif

--- a/test/plugins/TestInvalidQmlPlugin.qml
+++ b/test/plugins/TestInvalidQmlPlugin.qml
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+
+Rectangle {
+  banana: fail
+}

--- a/test/plugins/TestInvalidQmlPlugin.qrc
+++ b/test/plugins/TestInvalidQmlPlugin.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="TestInvalidQmlPlugin/">
+  <file>TestInvalidQmlPlugin.qml</file>
+</qresource>
+</RCC>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

I introduced a regression on #249, so plugins with invalid QML now crash instead of failing gracefully. This PR fixes that. Also added a test so we don't break it again in the future.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
