### PR TITLE
Set marker point size from message

### DIFF
--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -544,6 +544,10 @@ void MarkerManagerPrivate::SetMarker(const ignition::msgs::Marker &_msg,
 
     _markerPtr->AddPoint(vector, color);
   }
+  if (_msg.has_scale())
+  {
+    _markerPtr->SetSize(_msg.scale().x());
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1156

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Set the marker size based on the X element on the message's scale.

I'm using it in a plugin that's WIP:

![point_size](https://user-images.githubusercontent.com/5751272/142717114-933ec82f-0afd-4886-8f98-c49287057676.gif)



## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
