### PR TITLE
Set per-point color on markers

### DIFF
--- a/examples/standalone/marker/marker.cc
+++ b/examples/standalone/marker/marker.cc
@@ -121,6 +121,8 @@ int main(int _argc, char **_argv)
   markerMsg.set_id(3);
   ignition::msgs::Set(markerMsg.mutable_pose(),
                     ignition::math::Pose3d(0, 0, 0, 0, 0, 0));
+  ignition::msgs::Set(markerMsg.mutable_scale(),
+                    ignition::math::Vector3d(1.0, 1.0, 1.0));
   markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
   markerMsg.set_type(ignition::msgs::Marker::LINE_LIST);
   ignition::msgs::Set(markerMsg.add_point(),
@@ -146,11 +148,13 @@ int main(int _argc, char **_argv)
       ignition::math::Vector3d(0.5, 0.5, 0.05));
   node.Request("/marker", markerMsg);
 
-  std::cout << "Adding 100 points inside the square\n";
+  std::cout << "Adding 100 green points inside the square\n";
   std::this_thread::sleep_for(std::chrono::seconds(4));
   markerMsg.set_id(5);
   markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
   markerMsg.set_type(ignition::msgs::Marker::POINTS);
+  ignition::msgs::Set(markerMsg.mutable_scale(),
+                    ignition::math::Vector3d(5.0, 1.0, 1.0));
   markerMsg.clear_point();
   for (int i = 0; i < 100; ++i)
   {
@@ -162,9 +166,30 @@ int main(int _argc, char **_argv)
   }
   node.Request("/marker", markerMsg);
 
-  std::cout << "Adding a semi-circular triangle fan\n";
+  std::cout << "Adding 100 colored points next to the square\n";
   std::this_thread::sleep_for(std::chrono::seconds(4));
   markerMsg.set_id(6);
+  markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
+  markerMsg.set_type(ignition::msgs::Marker::POINTS);
+  markerMsg.clear_point();
+  for (int i = 0; i < 100; ++i)
+  {
+    ignition::msgs::Set(markerMsg.add_point(),
+        ignition::math::Vector3d(
+          ignition::math::Rand::DblUniform(-1.0, 1.0),
+          ignition::math::Rand::DblUniform(0.5, 1.0),
+          0.05));
+    ignition::msgs::Set(markerMsg.add_materials()->mutable_diffuse(),
+        ignition::math::Color(
+          ignition::math::Rand::DblUniform(0.0, 1.0),
+          ignition::math::Rand::DblUniform(0.0, 1.0),
+          ignition::math::Rand::DblUniform(0.0, 1.0)));
+  }
+  node.Request("/marker", markerMsg);
+
+  std::cout << "Adding a semi-circular triangle fan\n";
+  std::this_thread::sleep_for(std::chrono::seconds(4));
+  markerMsg.set_id(7);
   markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
   markerMsg.set_type(ignition::msgs::Marker::TRIANGLE_FAN);
   markerMsg.clear_point();
@@ -182,7 +207,7 @@ int main(int _argc, char **_argv)
 
   std::cout << "Adding two triangles using a triangle list\n";
   std::this_thread::sleep_for(std::chrono::seconds(4));
-  markerMsg.set_id(7);
+  markerMsg.set_id(8);
   markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
   markerMsg.set_type(ignition::msgs::Marker::TRIANGLE_LIST);
   markerMsg.clear_point();
@@ -206,7 +231,7 @@ int main(int _argc, char **_argv)
 
   std::cout << "Adding a rectangular triangle strip\n";
   std::this_thread::sleep_for(std::chrono::seconds(4));
-  markerMsg.set_id(8);
+  markerMsg.set_id(9);
   markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
   markerMsg.set_type(ignition::msgs::Marker::TRIANGLE_STRIP);
   markerMsg.clear_point();

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -286,7 +286,8 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const ignition::msgs::Marker &_msg)
 {
   // Get the namespace, if it exists. Otherwise, use the global namespace
   std::string ns;
-  if (!_msg.ns().empty()) {
+  if (!_msg.ns().empty())
+  {
     ns = _msg.ns();
   }
 
@@ -528,12 +529,6 @@ void MarkerManagerPrivate::SetMarker(const ignition::msgs::Marker &_msg,
     _markerPtr->ClearPoints();
   }
 
-  math::Color color(
-      _msg.material().diffuse().r(),
-      _msg.material().diffuse().g(),
-      _msg.material().diffuse().b(),
-      _msg.material().diffuse().a());
-
   // Set Marker Points
   for (int i = 0; i < _msg.point().size(); ++i)
   {
@@ -542,6 +537,11 @@ void MarkerManagerPrivate::SetMarker(const ignition::msgs::Marker &_msg,
         _msg.point(i).y(),
         _msg.point(i).z());
 
+    math::Color color = msgs::Convert(_msg.material().diffuse());
+    if (i < _msg.materials().size())
+    {
+      color = msgs::Convert(_msg.materials(i).diffuse());
+    }
     _markerPtr->AddPoint(vector, color);
   }
 }


### PR DESCRIPTION
# 🎉 New feature

Part of 
* https://github.com/ignitionrobotics/ign-gazebo/issues/1156

Requires

* https://github.com/ignitionrobotics/ign-rendering/pull/494
* https://github.com/ignitionrobotics/ign-msgs/pull/202

Builds on top of 

* https://github.com/ignitionrobotics/ign-gui/pull/317
* #321 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

If a message specifies multiple colors, use different colors for each point. Otherwise, fallback to current behaviour.

The branch is currently on `ign-gui6` while I work on the implementation, but the goal is to merge this into `main` after https://github.com/ignition-tooling/release-tools/issues/554.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Run the `marker` example and see that both the single material and the per-point material work:

![pts_color](https://user-images.githubusercontent.com/5751272/144188033-ef35fcb3-872e-4fd9-91c9-231bdd1db0d8.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
