### PR TITLE
use qmldir to define QML module with IgnSpinBox

### DIFF
--- a/include/ignition/gui/Application.hh
+++ b/include/ignition/gui/Application.hh
@@ -46,6 +46,10 @@ namespace ignition
     class MainWindow;
     class Plugin;
 
+
+    /// /brief Import path for ign-gui QML modules added to the Qt resource system
+    const char *const QML_QRC_IMPORT_PATH = "qrc:/ign-gui-qml/";
+
     /// \brief Type of window which the application will display
     enum class WindowType : int
     {

--- a/include/ignition/gui/Application.hh
+++ b/include/ignition/gui/Application.hh
@@ -46,10 +46,6 @@ namespace ignition
     class MainWindow;
     class Plugin;
 
-
-    /// /brief Import path for ign-gui QML modules added to the Qt resource system
-    const char *const QML_QRC_IMPORT_PATH = "qrc:/ign-gui-qml/";
-
     /// \brief Type of window which the application will display
     enum class WindowType : int
     {

--- a/include/ignition/gui/Helpers.hh
+++ b/include/ignition/gui/Helpers.hh
@@ -79,6 +79,16 @@ namespace ignition
     IGNITION_GUI_VISIBLE
     QStringList worldNames();
 
+
+    /// /brief Import path for ign-gui QML modules added to the Qt resource system
+    /// This helper function returns the QRC resource path where custom ignition QML
+    /// modules can be imported from. To import an ignition QML module, add this path
+    /// to the QML engine's import path list before attempting to load a QML file
+    /// that imports ignition QML modules.
+    /// \return Resousrce path prefix as a string
+    IGNITION_GUI_VISIBLE
+    const QString qmlQrcImportPath();
+
     /// \brief Returns the first element on a QList which matches the given
     /// property.
     /// \param[in] _list The list to search through.

--- a/include/ignition/gui/Helpers.hh
+++ b/include/ignition/gui/Helpers.hh
@@ -80,7 +80,7 @@ namespace ignition
     QStringList worldNames();
 
 
-    /// /brief Import path for ign-gui QML modules added to the Qt resource system
+    /// \brief Import path for ign-gui QML modules added to the Qt resource system
     /// This helper function returns the QRC resource path where custom ignition QML
     /// modules can be imported from. To import an ignition QML module, add this path
     /// to the QML engine's import path list before attempting to load a QML file

--- a/include/ignition/gui/qml/qmldir
+++ b/include/ignition/gui/qml/qmldir
@@ -1,0 +1,3 @@
+module ignition.gui
+
+IgnSpinBox 1.0 IgnSpinBox.qml

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -20,4 +20,8 @@
   <file>qml/images/menu.png</file>
   <file>qml/images/search.svg</file>
 </qresource>
+<qresource prefix="ign-gui-qml/ignition/gui">
+    <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
+    <file alias="qmldir">qml/qmldir</file>
+</qresource>
 </RCC>

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -21,7 +21,9 @@
   <file>qml/images/search.svg</file>
 </qresource>
 <qresource prefix="ign-gui-qml/ignition/gui">
-    <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
+    <!-- This qmldir file defines a QML module that can be imported -->
     <file alias="qmldir">qml/qmldir</file>
+    <!-- Add any QML components referenced in the qmldir file here -->
+    <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
 </qresource>
 </RCC>

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -91,6 +91,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
 
   // QML engine
   this->dataPtr->engine = new QQmlApplicationEngine();
+  this->dataPtr->engine->addImportPath(QML_QRC_IMPORT_PATH);
 
   // Install signal handler for graceful shutdown
   this->dataPtr->signalHandler.AddCallback(

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -28,6 +28,7 @@
 #include "ignition/gui/Application.hh"
 #include "ignition/gui/config.hh"
 #include "ignition/gui/Dialog.hh"
+#include "ignition/gui/Helpers.hh"
 #include "ignition/gui/MainWindow.hh"
 #include "ignition/gui/Plugin.hh"
 
@@ -91,7 +92,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
 
   // QML engine
   this->dataPtr->engine = new QQmlApplicationEngine();
-  this->dataPtr->engine->addImportPath(QML_QRC_IMPORT_PATH);
+  this->dataPtr->engine->addImportPath(qmlQrcImportPath());
 
   // Install signal handler for graceful shutdown
   this->dataPtr->signalHandler.AddCallback(

--- a/src/Helpers.cc
+++ b/src/Helpers.cc
@@ -180,3 +180,9 @@ QStringList ignition::gui::worldNames()
 
   return worldNamesVariant.toStringList();
 }
+
+/////////////////////////////////////////////////
+const QString ignition::gui::qmlQrcImportPath()
+{
+  return "qrc:/ign-gui-qml/";
+}

--- a/src/plugins/teleop/Teleop.qml
+++ b/src/plugins/teleop/Teleop.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.1
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
-import "qrc:/qml"
+import ignition.gui 1.0
 
 Rectangle {
   color:"transparent"


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🎉 New feature

Closes #310 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This change adds a qmldir file that defines an importable QML module for common QML components implemented in `include/ignition/gui/qml/`.

With this change, it will be possible to import QML components using module import statements instead of file path.

Updating import statements will look like this:

```diff
-import "qrc:/qml"
+import ignition.gui 1.0
```

## Test it
<!--Explain how reviewers can test this new feature manually.-->

* Build and run the application `ign run`
* Add the "Teleop" plugin
* Verify that the plugin loads and that the `IgnSpinBox` is part of the UI

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
