### PR TITLE
Don't set visual scale for point markers

### DIFF
--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -445,7 +445,8 @@ void MarkerManagerPrivate::SetVisual(const ignition::msgs::Marker &_msg,
                            const rendering::VisualPtr &_visualPtr)
 {
   // Set Visual Scale
-  if (_msg.has_scale())
+  // The scale for points is used as the size of each point, so skip it here.
+  if (_msg.has_scale() && _msg.type() != ignition::msgs::Marker::POINTS)
   {
     _visualPtr->SetLocalScale(_msg.scale().x(),
                               _msg.scale().y(),


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This is a follow up to #317. The scale is currently being applied to the entire visual, so points end up further apart as we increase it. I'm not sure if this is a use case that anyone would rely on. My suggestion is to skip setting the visual scale for points, and use the scale just for point size.

Before | After
-- | --
![before_ptscale](https://user-images.githubusercontent.com/5751272/143328290-86cd7cda-aa98-427c-b5ff-6d747f60ca94.gif) | ![after_ptscale](https://user-images.githubusercontent.com/5751272/143328297-e0ab90aa-998d-4b64-94d5-1842cc8f9886.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
