### PR TITLE
Fix message display in TopicEcho

### DIFF
--- a/src/plugins/topic_echo/TopicEcho.qml
+++ b/src/plugins/topic_echo/TopicEcho.qml
@@ -97,8 +97,8 @@ Rectangle {
         currentIndex: -1
 
         delegate: ItemDelegate {
-          width: parent.width
-          text: display
+          width: listView.width
+          text: model.display
         }
 
         model: TopicEchoMsgList


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR fixes a problem with the TopicEcho plugin where the message is not displayed correctly.

This may be apparent on macOS because of the Qt version installed using homebrew (details below).

- Change the binding of the `width` property in ListView delegate (see: https://stackoverflow.com/questions/63767669/parent-is-null-in-listview-delegate-after-upgrade-to-qt-5-15)
- Use scoped references `model.display` (see: https://forum.qt.io/topic/92085/using-qstringlistmodel-as-model-in-listview)


### System

OS: macOS Big Sur 11.6.4

Qt version: 5.15.2

```bash
$ brew info qt@5
qt@5: stable 5.15.2 (bottled) [keg-only]
Cross-platform application and UI framework
https://www.qt.io/
/usr/local/Cellar/qt@5/5.15.2_1 (10,688 files, 365.9MB)
  Poured from bottle on 2021-10-22 at 15:10:42
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/qt@5.rb
License: GFDL-1.3-only and GPL-2.0-only and GPL-3.0-only and LGPL-2.1-only and LGPL-3.0-only
==> Dependencies
Build: pkg-config ✔
==> Requirements
Build: Xcode ✔
Required: macOS >= 10.12 ✔
```

### Before

The messages are not displayed correctly and a warning is printed to the terminal. 

```bash
$ ign gui -c examples/config/pubsub.config
...
[GUI] [Wrn] [Application.cc:698] [QT] file::/TopicEcho/TopicEcho.qml:105: TypeError: Cannot read property 'width' of null
```

![topicecho_before](https://user-images.githubusercontent.com/24916364/143450230-2eec227d-2a02-468a-9426-d957764fe33f.png)

### After

The messages display as expected and there is no warning.

![topicecho_after](https://user-images.githubusercontent.com/24916364/143450280-0d14d5d8-8251-4e37-924c-18359766e01b.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**