### PR TITLE
Add PreRender event to MinimalScene

### DIFF
--- a/include/ignition/gui/GuiEvents.hh
+++ b/include/ignition/gui/GuiEvents.hh
@@ -42,7 +42,8 @@ namespace ignition
       /// User defined events should start from QEvent::MaxUser and
       /// count down to avoid collision with ign-gazebo events
 
-      /// \brief Event called in the render thread of a 3D scene.
+      /// \brief Event called in the render thread of a 3D scene after the user
+      /// camera has rendered.
       /// It's safe to make rendering calls in this event's callback.
       class Render : public QEvent
       {
@@ -464,6 +465,22 @@ namespace ignition
         /// \brief Get the WorldControl information
         /// \return The WorldControl information
         public: const msgs::WorldControl &WorldControlInfo() const;
+
+        /// \internal
+        /// \brief Private data pointer
+        IGN_UTILS_IMPL_PTR(dataPtr)
+      };
+
+      /// \brief Event called in the render thread of a 3D scene, before the
+      /// user camera is rendered.
+      /// It's safe to make rendering calls in this event's callback.
+      class IGNITION_GUI_VISIBLE PreRender : public QEvent
+      {
+        /// \brief Constructor
+        public: PreRender();
+
+        /// \brief Unique type for this event.
+        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 20);
 
         /// \internal
         /// \brief Private data pointer

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -142,6 +142,10 @@ class ignition::gui::events::WorldControl::Implementation
   public: msgs::WorldControl worldControl;
 };
 
+class ignition::gui::events::PreRender::Implementation
+{
+};
+
 using namespace ignition;
 using namespace gui;
 using namespace events;
@@ -419,4 +423,10 @@ WorldControl::WorldControl(const msgs::WorldControl &_worldControl)
 const msgs::WorldControl &WorldControl::WorldControlInfo() const
 {
   return this->dataPtr->worldControl;
+}
+
+/////////////////////////////////////////////////
+PreRender::PreRender()
+  : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
+{
 }

--- a/src/GuiEvents_TEST.cc
+++ b/src/GuiEvents_TEST.cc
@@ -283,3 +283,11 @@ TEST(GuiEventsTest, WorldControl)
   EXPECT_EQ(2, playEvent.WorldControlInfo().run_to_sim_time().sec());
   EXPECT_EQ(3, playEvent.WorldControlInfo().run_to_sim_time().nsec());
 }
+
+/////////////////////////////////////////////////
+TEST(GuiEventsTest, PreRender)
+{
+  events::PreRender event;
+
+  EXPECT_LT(QEvent::User, event.type());
+}

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -305,6 +305,13 @@ void IgnRenderer::Render(RenderSync *_renderSync)
   // view control
   this->HandleMouseEvent();
 
+  if (ignition::gui::App())
+  {
+    ignition::gui::App()->sendEvent(
+        ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
+        new gui::events::PreRender());
+  }
+
   // update and render to texture
   this->dataPtr->camera->Update();
 

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -100,18 +100,36 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   // Show, but don't exec, so we don't block
   win->QuickWindow()->show();
 
+  // Filter events
+  bool receivedPreRenderEvent{false};
+  bool receivedRenderEvent{false};
+  auto testHelper = std::make_unique<TestHelper>();
+  testHelper->forwardEvent = [&](QEvent *_event)
+  {
+    if (_event->type() == events::PreRender::kType)
+    {
+      receivedPreRenderEvent = true;
+    }
+    if (_event->type() == events::Render::kType)
+    {
+      receivedRenderEvent = true;
+    }
+  };
+
   // Check scene
   auto engine = rendering::engine("ogre");
   ASSERT_NE(nullptr, engine);
 
   int sleep = 0;
   int maxSleep = 30;
-  while (0 == engine->SceneCount() && sleep < maxSleep)
+  while (!receivedRenderEvent && sleep < maxSleep)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     QCoreApplication::processEvents();
     sleep++;
   }
+  EXPECT_TRUE(receivedPreRenderEvent);
+  EXPECT_TRUE(receivedRenderEvent);
 
   EXPECT_EQ(1u, engine->SceneCount());
   auto scene = engine->SceneByName("banana");

--- a/tutorials/scene.md
+++ b/tutorials/scene.md
@@ -56,7 +56,8 @@ every iteration until it succeeds. This way, it can find a 3D scene even if
 Rendering operations aren't thread-safe. To make sure there are no race
 conditions, all rendering operations should happen in the same thread, the
 "render thread". In order to access that thread from a custom plugin, it's
-necessary to listen to the `ignition::gui::events::Render` event, which is
+necessary to listen to the `ignition::gui::events::Render` or
+`ignition::gui::events::PreRender` events, which are
 emitted by the `MinimalScene`.
 
 See how the `TransportSceneManager` installs an event filter with


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

The new `PreRender` event is triggered right before the camera is updated, so plugins can make modifications that will be reflected on the current frame.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

I added a test that makes sure the event is triggered.

I'm also using this event in a downstream plugin to place some gizmos right in front of the camera. If I do this on the `Render` event, I get some jitter:

![axes](https://user-images.githubusercontent.com/5751272/144521081-44027990-1dca-4b77-8c27-01681d412fbb.gif)


But with `PreRender` they stay in place:

![prerender](https://user-images.githubusercontent.com/5751272/144521055-5711f8e6-33ca-4df2-9c73-60e64dae086d.gif)


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
