### PR TITLE
Offer a way to disable warnings on marker manager

### DIFF
--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -134,6 +134,10 @@ class ignition::gui::plugins::MarkerManagerPrivate
 
   /// \brief The last marker message received
   public: ignition::msgs::Marker msg;
+
+  /// \brief True to print console warnings if the user tries to perform an
+  /// action with an inexistent marker.
+  public: bool warnOnActionFailure{true};
 };
 
 using namespace ignition;
@@ -392,8 +396,11 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const ignition::msgs::Marker &_msg)
     }
     else
     {
-      ignwarn << "Unable to delete marker with id[" << id << "] "
-        << "in namespace[" << ns << "]" << std::endl;
+      if (this->warnOnActionFailure)
+      {
+        ignwarn << "Unable to delete marker with id[" << id << "] "
+          << "in namespace[" << ns << "]" << std::endl;
+      }
       return false;
     }
   }
@@ -403,8 +410,11 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const ignition::msgs::Marker &_msg)
     // If given namespace doesn't exist
     if (!ns.empty() && nsIter == this->visuals.end())
     {
-      ignwarn << "Unable to delete all markers in namespace[" << ns <<
-          "], namespace can't be found." << std::endl;
+      if (this->warnOnActionFailure)
+      {
+        ignwarn << "Unable to delete all markers in namespace[" << ns <<
+           "], namespace can't be found." << std::endl;
+      }
       return false;
     }
     // Remove all markers in the specified namespace
@@ -681,6 +691,16 @@ void MarkerManager::LoadConfig(const tinyxml2::XMLElement * _pluginElem)
       {
         ignerr << "the provided topic is no allowed. Using default ["
                << this->dataPtr->topicName << "]"<<  std::endl;
+      }
+    }
+
+    if ((elem = _pluginElem->FirstChildElement("warn_on_action_failure")))
+    {
+      if (elem->QueryBoolText(&this->dataPtr->warnOnActionFailure) !=
+          tinyxml2::XML_SUCCESS)
+      {
+        ignerr << "Faild to parse <warn_on_action_failure> value: "
+               << elem->GetText() << std::endl;
       }
     }
 

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -399,7 +399,7 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const ignition::msgs::Marker &_msg)
       if (this->warnOnActionFailure)
       {
         ignwarn << "Unable to delete marker with id[" << id << "] "
-          << "in namespace[" << ns << "]" << std::endl;
+                << "in namespace[" << ns << "]" << std::endl;
       }
       return false;
     }
@@ -412,8 +412,8 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const ignition::msgs::Marker &_msg)
     {
       if (this->warnOnActionFailure)
       {
-        ignwarn << "Unable to delete all markers in namespace[" << ns <<
-           "], namespace can't be found." << std::endl;
+        ignwarn << "Unable to delete all markers in namespace[" << ns 
+                << "], namespace can't be found." << std::endl;
       }
       return false;
     }

--- a/src/plugins/marker_manager/MarkerManager.hh
+++ b/src/plugins/marker_manager/MarkerManager.hh
@@ -32,6 +32,13 @@ namespace plugins
 
   /// \brief This plugin will be in charge of handeling the markers in the
   /// scene. It will allow to add, modify or remove markers.
+  ///
+  /// ## Parameters
+  ///
+  /// * `<topic_name>`: Options. Name of topic for marker service. Defaults
+  /// to `/marker`.
+  /// * `<warn_on_action_failure>`: True to display warnings if the user
+  /// attempts to perform an invalid action. Defaults to true.
   class MarkerManager : public Plugin
   {
     Q_OBJECT


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Sometimes it's nice to treat the marker actions as idempotent, so performing the same action multiple times is not an error. But for other use cases, it may be expected that actions like deleting an nonexistent marker are mistakes. So I added a way of disabling the warnings while maintaining the default behaviour.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Try to delete markers in a nonexistent namespace. By default you'll see a warning, but if you add `<warn_on_action_failure>false</warn_on_action_failure>` to the plugin, then no warning is printed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
