### PR TITLE
Add project() to examples and remove hard-dependency on Ogre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering
+# TODO(chapulina) Remove this once ign-rendering exports the variable
+# https://github.com/ignitionrobotics/ign-rendering/issues/360
+if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
+  set(OpenGL_GL_PREFERENCE "GLVND")
+endif()
 ign_find_package(ignition-rendering3 REQUIRED COMPONENTS ogre VERSION 3.5.0)
 set(IGN_RENDERING_VER ${ignition-rendering3_VERSION_MAJOR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,7 @@ set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering
-# TODO(chapulina) Remove this once ign-rendering exports the variable
-# https://github.com/ignitionrobotics/ign-rendering/issues/360
-if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
-  set(OpenGL_GL_PREFERENCE "GLVND")
-endif()
-ign_find_package(ignition-rendering3 REQUIRED COMPONENTS ogre VERSION 3.5.0)
+ign_find_package(ignition-rendering3 REQUIRED VERSION 3.5.0)
 set(IGN_RENDERING_VER ${ignition-rendering3_VERSION_MAJOR})
 
 #--------------------------------------

--- a/examples/plugin/custom_context_menu/CMakeLists.txt
+++ b/examples/plugin/custom_context_menu/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-custom-context-menu)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/plugin/dialog_from_plugin/CMakeLists.txt
+++ b/examples/plugin/dialog_from_plugin/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-dialog-from-plugin)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/plugin/hello_plugin/CMakeLists.txt
+++ b/examples/plugin/hello_plugin/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-hello-plugin)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/plugin/ign_components/CMakeLists.txt
+++ b/examples/plugin/ign_components/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-ign-components)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/plugin/multiple_qml/CMakeLists.txt
+++ b/examples/plugin/multiple_qml/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-multiple-qml)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/standalone/custom_drawer/CMakeLists.txt
+++ b/examples/standalone/custom_drawer/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-custom-drawer)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/standalone/dialogs/CMakeLists.txt
+++ b/examples/standalone/dialogs/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-dialogs)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()

--- a/examples/standalone/window/CMakeLists.txt
+++ b/examples/standalone/window/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
+project(ignition-gui-window)
+
 if(POLICY CMP0100)
   cmake_policy(SET CMP0100 NEW)
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This is needed to silence CMake warnings like this:

```
33: CMake Warning (dev) in CMakeLists.txt:
33:   No project() command is present.  The top-level CMakeLists.txt file must
33:   contain a literal, direct call to the project() command.  Add a line of
33:   code such as
33: 
33:     project(ProjectName)
33: 
33:   near the top of the file, but after cmake_minimum_required().
33: 
33:   CMake is pretending there is a "project(Project)" command on the first
33:   line.
33: This warning is for project developers.  Use -Wno-dev to suppress it.
```

These warnings show up on Jenkins CI since we migrated from Bionic to Focal:

* https://github.com/ignition-tooling/release-tools/pull/565

~~There's still another warning coming from `ign-rendering`, tracked here:~~

I added a workaround for the warning coming from `ign-rendering` until we fix it upstream

* https://github.com/ignitionrobotics/ign-rendering/issues/360

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
