### PR TITLE
🎈 3.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui3 VERSION 3.8.0)
+project(ignition-gui3 VERSION 3.9.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,30 @@
 ## Ignition Gui 3
 
-### Ignition Gui 3.X.X (202X-XX-XX)
+### Ignition Gui 3.9.0 (2022-01-14)
+
+1. Added a button that allows shutting down both the client and server.
+    * [Pull request #335](https://github.com/ignitionrobotics/ign-gui/pull/335)
+
+1. Prevent Scene3D 💥 if another scene is already loaded
+    * [Pull request #347](https://github.com/ignitionrobotics/ign-gui/pull/347)
+
+1. Add project() to examples and remove hard-dependency on Ogre1
+    * [Pull request #345](https://github.com/ignitionrobotics/ign-gui/pull/345)
+
+1. Fix codecheck
+    * [Pull request #329](https://github.com/ignitionrobotics/ign-gui/pull/329)
+
+1. Use `qmldir` to define QML module with `IgnSpinBox`
+    * [Pull request #319](https://github.com/ignitionrobotics/ign-gui/pull/319)
+
+1. Fix `TopicEcho` plugin message display
+    * [Pull request #322](https://github.com/ignitionrobotics/ign-gui/pull/322)
+
+1. Don't crash if a plugin has invalid QML
+    * [Pull request #315](https://github.com/ignitionrobotics/ign-gui/pull/315)
+
+1. Added log storing for `ign gui` CLI
+    * [Pull request #272](https://github.com/ignitionrobotics/ign-gui/pull/272)
 
 ### Ignition Gui 3.8.0 (2021-10-12)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.9.0 release.

Comparison to 3.8.0: https://github.com/ignitionrobotics/ign-gui/compare/ignition-gui3_3.8.0...ign-gui3

The main motivation for this release is to fix CMP0072 warnings on `ign-gazebo`, see

* https://github.com/ignitionrobotics/ign-gui/pull/345
* https://github.com/ignitionrobotics/ign-rendering/issues/360

## Checklist

- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): Not removing Ogre from there, so users still get some rendering engine when installing Ignition GUI.

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
