### PR TITLE
Improve KeyPublisher's usability

### DIFF
--- a/src/plugins/key_publisher/KeyPublisher.qml
+++ b/src/plugins/key_publisher/KeyPublisher.qml
@@ -15,13 +15,30 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-Rectangle {
-    visible: false
-    Layout.minimumWidth: 100
-    Layout.minimumHeight: 100
+GridLayout {
+  columns: 1
+  columnSpacing: 10
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 200
+  anchors.fill: parent
+  anchors.margins: 10
+
+  Label {
+    Layout.columnSpan: 1
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: "Keystrokes are being published to topic:\n'/keyboard/keypress'."
+  }
+
+
+  Item {
+    Layout.columnSpan: 1
+    width: 10
+    Layout.fillHeight: true
+  }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

A new user inserting the `KeyPublisher` plugin may get confused when they just see an empty plugin. With this PR, the plugin provides more information to the user:

![keypublisher](https://user-images.githubusercontent.com/5751272/156480592-163ff262-472d-4242-8c77-4e0948b64ecb.png)

This shouldn't affect use cases where the plugin is placed floating with a small size, like [this](https://github.com/ignitionrobotics/ign-gazebo/blob/6ac12c6d9c474ab06bea55967ad1bb4adfa8700d/examples/worlds/conveyor.sdf#L318-L330).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
