### PR TITLE
Backport GridConfig improvements to Citadel's Grid3D

### DIFF
--- a/src/plugins/grid_3d/Grid3D.hh
+++ b/src/plugins/grid_3d/Grid3D.hh
@@ -30,6 +30,9 @@ namespace plugins
 {
   class Grid3DPrivate;
 
+  // TODO(chapulina)
+  // Delete this plugin when forward porting to `ign-gui6` in favor of `GridConfig`
+
   /// \brief Manages grids in an Ignition Rendering scene. This plugin can be
   /// used for:
   /// * Introspecting grids

--- a/src/plugins/grid_3d/Grid3D.hh
+++ b/src/plugins/grid_3d/Grid3D.hh
@@ -20,7 +20,6 @@
 
 #include <memory>
 
-#include "ignition/gui/qt.h"
 #include "ignition/gui/Plugin.hh"
 
 namespace ignition
@@ -33,22 +32,15 @@ namespace plugins
 
   /// \brief Manages grids in an Ignition Rendering scene. This plugin can be
   /// used for:
-  /// * Adding grids
   /// * Introspecting grids
   /// * Editing grids
-  /// * Deleting grids
   ///
   /// ## Configuration
   ///
-  /// * \<engine\> : Optional render engine name, defaults to the first loaded
-  ///                engine.
-  /// * \<scene\> : Optional scene name, defaults to the first loaded scene.
-  /// * \<auto_close\> : Set to true so the plugin closes after grids given by
-  ///                    \<insert\> tags are added to the scene.
   /// * \<insert\> : One grid will be inserted at startup for each \<insert\>
   ///                tag.
-  ///   * \<cell_count\> : Number of cells in the horizontal direction, defaults
-  ///                      to 20.
+  ///   * \<horizontal_cell_count\> : Number of cells in the horizontal
+  ///                                 direction, defaults to 20.
   ///   * \<vertical_cell_count\> : Number of cells in the vertical direction,
   ///                               defaults to 0;
   ///   * \<cell_length\> : Length of each cell, defaults to 1.
@@ -58,30 +50,97 @@ namespace plugins
   {
     Q_OBJECT
 
+    /// \brief Name list
+    Q_PROPERTY(
+      QStringList nameList
+      READ NameList
+      WRITE SetNameList
+      NOTIFY NameListChanged
+    )
+
     /// \brief Constructor
     public: Grid3D();
 
     /// \brief Destructor
-    public: virtual ~Grid3D();
+    public: ~Grid3D() override;
 
     // Documentation inherited
     public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         override;
 
-    private slots: void Initialize();
+    // Documentation inherited
+    protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    /// \brief Called when a value changes on a widget
-    /// \param[in] _value New value
-    private slots: void OnChange(const QVariant &_value);
+    /// \brief Create grids defined at startup
+    public: void CreateGrids();
 
-    /// \brief Callback when a delete button is pressed.
-    private slots: void OnDelete();
+    /// \brief Update grid
+    public: void UpdateGrid();
 
-    /// \brief Callback when the add button is pressed.
-    private slots: void OnAdd();
+    /// \brief Callback to retrieve existing grid.
+    public: void ConnectToGrid();
 
-    /// \brief Callback when the refresh button is pressed.
-    private slots: void Refresh();
+    /// \brief Refresh list of grids. This is called in the rendering thread.
+    public: void RefreshList();
+
+    /// \brief Callback when refresh button is pressed.
+    public slots: void OnRefresh();
+
+    /// \brief Callback when a new name is chosen on the combo box.
+    /// \param[in] _name Grid name
+    public slots: void OnName(const QString &_name);
+
+    /// \brief Get the list of grid names
+    /// \return List of grids.
+    public slots: QStringList NameList() const;
+
+    /// \brief Set the list of names
+    /// \param[in] _nameList List of names
+    public slots: void SetNameList(const QStringList &_nameList);
+
+    /// \brief Notify that name list has changed
+    signals: void NameListChanged();
+
+    /// \brief Callback to update vertical cell count
+    /// \param[in] _cellCount new vertical cell count
+    public slots: void UpdateVCellCount(int _cellCount);
+
+    /// \brief Callback to update horizontal cell count
+    /// \param[in] _cellCount new horizontal cell count
+    public slots: void UpdateHCellCount(int _cellCount);
+
+    /// \brief Callback to update cell length
+    /// \param[in] _length new cell length
+    public slots: void UpdateCellLength(double _length);
+
+    /// \brief Callback to update grid pose
+    /// \param[in] _x, _y, _z cartesion coordinates
+    /// \param[in] _roll, _pitch, _yaw principal coordinates
+    public slots: void SetPose(double _x, double _y, double _z,
+                               double _roll, double _pitch, double _yaw);
+
+    /// \brief Callback to update grid color
+    /// \param[in] _r, _g, _b, _a RGB color model with fourth alpha channel
+    public slots: void SetColor(double _r, double _g, double _b, double _a);
+
+    /// \brief Callback when checkbox is clicked.
+    /// \param[in] _checked indicates show or hide grid
+    public slots: void OnShow(bool _checked);
+
+    /// \brief Notify QML that grid values have changed.
+    /// \param[in] _hCellCount Horizontal cell count
+    /// \param[in] _vCellCount Vertical cell count
+    /// \param[in] _cellLength Cell length
+    /// \param[in] _pos XYZ Position
+    /// \param[in] _rot RPY orientation
+    /// \param[in] _color Grid color
+    signals: void newParams(
+        int _hCellCount,
+        int _vCellCount,
+        double _cellLength,
+        QVector3D _pos,
+        QVector3D _rot,
+        QColor _color);
 
     /// \internal
     /// \brief Pointer to private data.

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -14,13 +14,370 @@
  * limitations under the License.
  *
 */
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
+import QtQuick.Controls.Material 2.1
+import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
+import "qrc:/qml"
 
-Rectangle {
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+GridLayout {
+  columns: 4
+  columnSpacing: 10
+  Layout.minimumWidth: 300
+  Layout.minimumHeight: 625
+  anchors.fill: parent
+  anchors.leftMargin: 10
+  anchors.rightMargin: 10
+
+  // Get number of decimal digits based on a widget's width
+  // TODO(chapulina) Move this to a common place so all widgets can use it
+  function getDecimals(_width) {
+    if (_width <= 80)
+      return 2;
+    else if (_width <= 100)
+      return 4;
+    return 6;
+  }
+
+  Connections {
+    target: Grid3D
+    onNewParams: {
+      horizontalCellCount.value = _hCellCount;
+      verticalCellCount.value = _vCellCount;
+      cellLength.value = _cellLength;
+      x.value = _pos.x;
+      y.value = _pos.y;
+      z.value = _pos.z;
+      roll.value = _rot.x;
+      pitch.value = _rot.y;
+      yaw.value = _rot.z;
+      r.value = _color.r;
+      g.value = _color.g;
+      b.value = _color.b;
+      a.value = _color.a;
+    }
+  }
+
+  ComboBox {
+    id: combo
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    model: Grid3D.nameList
+    onCurrentIndexChanged: {
+      if (currentIndex < 0)
+        return;
+
+      Grid3D.OnName(textAt(currentIndex));
+    }
+    popup.width: parent.width
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Grids in the scene")
+  }
+
+  RoundButton {
+    text: "\u21bb"
+    Layout.columnSpan: 1
+    Material.background: Material.primary
+    onClicked: {
+      Grid3D.OnRefresh();
+    }
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Refresh list of grids")
+  }
+
+  CheckBox {
+    Layout.alignment: Qt.AlignHCenter
+    id: showgrid
+    Layout.columnSpan: 1
+    text: qsTr("Show")
+    checked: true
+    onClicked: {
+      Grid3D.OnShow(checked)
+    }
+  }
+
+  Text {
+    Layout.columnSpan: 4
+    text: "Cell Count"
+    color: "dimgrey"
+    font.bold: true
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: vercelltext
+    color: "dimgrey"
+    text: "Vertical"
+  }
+
+  IgnSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: verticalCellCount
+    maximumValue: Number.MAX_VALUE
+    minimumValue: 0
+    value: 0
+    onEditingFinished: Grid3D.UpdateVCellCount(verticalCellCount.value)
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: honcelltext
+    color: "dimgrey"
+    text: "Horizontal"
+  }
+
+  IgnSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: horizontalCellCount
+    maximumValue: Number.MAX_VALUE
+    minimumValue: 1
+    value: 20
+    onEditingFinished: Grid3D.UpdateHCellCount(horizontalCellCount.value)
+  }
+
+  Text {
+    Layout.columnSpan: 4
+    id: celllengthtext
+    text: "Cell Length"
+    color: "dimgrey"
+    font.bold: true
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: length
+    color: "dimgrey"
+    text: "Length (m)"
+  }
+  IgnSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: cellLength
+    maximumValue: Number.MAX_VALUE
+    minimumValue: 0.0000001
+    value: 1.00
+    decimals: getDecimals(cellLength.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.UpdateCellLength(cellLength.value)
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: cartesian
+    color: "dimgrey"
+    font.bold: true
+    text: "Position (m)"
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: principal
+    text: "Rotation (rad)"
+    color: "dimgrey"
+    font.bold: true
+  }
+
+  Text {
+    text: "X"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: x
+    value: 0.00
+    maximumValue: Number.MAX_VALUE
+    minimumValue: -Number.MAX_VALUE
+    decimals: getDecimals(x.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+  }
+
+  Text {
+    text: "Roll"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: roll
+    maximumValue: 6.28
+    minimumValue: 0.00
+    value: 0.00
+    decimals: getDecimals(roll.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+  }
+
+  Text {
+    text: "Y"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: y
+    value: 0.00
+    maximumValue: Number.MAX_VALUE
+    minimumValue: -Number.MAX_VALUE
+    decimals: getDecimals(y.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+  }
+
+  Text {
+    text: "Pitch"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: pitch
+    maximumValue: 6.28
+    minimumValue: 0.00
+    value: 0.00
+    decimals: getDecimals(pitch.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+  }
+
+  Text {
+    text: "Z"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: z
+    value: 0.00
+    maximumValue: Number.MAX_VALUE
+    minimumValue: -Number.MAX_VALUE
+    decimals: getDecimals(z.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+  }
+
+  Text {
+    text: "Yaw"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: yaw
+    maximumValue: 6.28
+    minimumValue: 0.00
+    value: 0.00
+    decimals: getDecimals(yaw.width)
+    stepSize: 0.01
+    onEditingFinished: Grid3D.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+  }
+
+  Text {
+    Layout.columnSpan: 4
+    text: "Color"
+    color: "dimgrey"
+    font.bold: true
+  }
+
+  Text {
+    text: "R"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: r
+    maximumValue: 1.00
+    minimumValue: 0.00
+    value: 0.7
+    stepSize: 0.01
+    decimals: getDecimals(r.width)
+    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
+  }
+
+  Text {
+    text: "G"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: g
+    maximumValue: 1.00
+    minimumValue: 0.00
+    value: 0.7
+    stepSize: 0.01
+    decimals: getDecimals(g.width)
+    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
+  }
+
+  Text {
+    text: "B"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: b
+    maximumValue: 1.00
+    minimumValue: 0.00
+    value: 0.7
+    stepSize: 0.01
+    decimals: getDecimals(b.width)
+    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
+  }
+
+  Text {
+    text: "A"
+    color: "dimgrey"
+  }
+
+  IgnSpinBox {
+    Layout.fillWidth: true
+    id: a
+    maximumValue: 1.00
+    minimumValue: 0.00
+    value: 1.0
+    stepSize: 0.01
+    decimals: getDecimals(a.width)
+    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
+  }
+
+  Button {
+    Layout.alignment: Qt.AlignHCenter
+    Layout.columnSpan: 4
+    id: color
+    text: qsTr("Custom Color")
+    onClicked: colorDialog.open()
+
+    ColorDialog {
+      id: colorDialog
+      title: "Choose a grid color"
+      visible: false
+      onAccepted: {
+        r.value = colorDialog.color.r
+        g.value = colorDialog.color.g
+        b.value = colorDialog.color.b
+        a.value = colorDialog.color.a
+        Grid3D.SetColor(colorDialog.color.r, colorDialog.color.g, colorDialog.color.b, colorDialog.color.a)
+        colorDialog.close()
+      }
+      onRejected: {
+        colorDialog.close()
+      }
+    }
+  }
+
+  // Bottom spacer
+  Item {
+    Layout.columnSpan: 4
+    Layout.fillHeight: true
+  }
 }
-
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

#324 made multiple improvements to `GridConfig` and `Grid3D`, and also consolidated them into the same plugin. That went into Fortress.

On Citadel, `GridConfig` is on `ign-gazebo`, while `Grid3D` is on `ign-gui` (`GridConfig` was moved to `ign-gui` in #236 ). So what this PR does is copy the `GridConfig` code from `ign-gui6` into `ign-gui3`'s `Grid3D`.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Load the `Grid3D` plugin from the menu on `ign-gazebo`, for example.

![image](https://user-images.githubusercontent.com/5751272/156491313-19321fa3-b1e3-45ed-9775-31f386f25af9.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
