### PR TITLE
Prevent MinimalScene 💥 if another scene is already loaded

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -385,6 +385,12 @@ std::string Application::DefaultConfigPath()
 bool Application::LoadPlugin(const std::string &_filename,
     const tinyxml2::XMLElement *_pluginElem)
 {
+  if (_filename.empty())
+  {
+    ignerr << "Trying to load plugin with empty filename." << std::endl;
+    return false;
+  }
+
   igndbg << "Loading plugin [" << _filename << "]" << std::endl;
 
   common::SystemPaths systemPaths;

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -36,13 +36,18 @@ namespace gui
 {
 namespace plugins
 {
-  /// \brief Creates a new ignition rendering scene or adds a user-camera to an
-  /// existing scene. It is possible to orbit the camera around the scene with
+  /// \brief Creates an ignition rendering scene and user camera.
+  /// It is possible to orbit the camera around the scene with
   /// the mouse. Use other plugins to manage objects in the scene.
+  ///
+  /// Only one plugin displaying an Ignition Rendering scene can be used at a
+  /// time.
   ///
   /// ## Configuration
   ///
-  /// * \<engine\> : Optional render engine name, defaults to 'ogre'.
+  /// * \<engine\> : Optional render engine name, defaults to 'ogre'. If another
+  ///                engine is already loaded, that will be used, because only
+  ///                one engine is supported at a time currently.
   /// * \<scene\> : Optional scene name, defaults to 'scene'. The plugin will
   ///               create a scene with this name if there isn't one yet. If
   ///               there is already one, a new camera is added to it.
@@ -59,6 +64,14 @@ namespace plugins
   class MinimalScene : public Plugin
   {
     Q_OBJECT
+
+    /// \brief Loading error message
+    Q_PROPERTY(
+      QString loadingError
+      READ LoadingError
+      WRITE SetLoadingError
+      NOTIFY LoadingErrorChanged
+    )
 
     /// \brief Constructor
     public: MinimalScene();
@@ -83,6 +96,20 @@ namespace plugins
     public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         override;
 
+    /// \brief Get the loading error string.
+    /// \return String explaining the loading error. If empty, there's no error.
+    public: Q_INVOKABLE QString LoadingError() const;
+
+    /// \brief Set the loading error message.
+    /// \param[in] _loadingError Error message.
+    public: Q_INVOKABLE void SetLoadingError(const QString &_loadingError);
+
+    /// \brief Notify that loading error has changed
+    signals: void LoadingErrorChanged();
+
+    /// \brief Loading error message
+    public: QString loadingError;
+
     /// \internal
     /// \brief Pointer to private data.
     IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
@@ -106,7 +133,9 @@ namespace plugins
     public: void Render(RenderSync *_renderSync);
 
     /// \brief Initialize the render engine
-    public: void Initialize();
+    /// \return Error message if initialization failed. If empty, no errors
+    /// occurred.
+    public: std::string Initialize();
 
     /// \brief Destroy camera associated with this renderer
     public: void Destroy();
@@ -238,6 +267,13 @@ namespace plugins
     /// \param[in] _size Size of the texture
     signals: void TextureReady(uint _id, const QSize &_size);
 
+    /// \brief Set a callback to be called in case there are errors.
+    /// \param[in] _cb Error callback
+    public: void SetErrorCb(std::function<void(const QString &)> _cb);
+
+    /// \brief Function to be called if there are errors.
+    public: std::function<void(const QString &)> errorCb;
+
     /// \brief Offscreen surface to render to
     public: QOffscreenSurface *surface = nullptr;
 
@@ -312,6 +348,13 @@ namespace plugins
     /// \brief Handle key release event for snapping
     /// \param[in] _e The key event to process.
     public: void HandleKeyRelease(const common::KeyEvent &_e);
+
+    /// \brief Set a callback to be called in case there are errors.
+    /// \param[in] _cb Error callback
+    public: void SetErrorCb(std::function<void(const QString &)> _cb);
+
+    /// \brief Stop rendering and shutdown resources.
+    public: void StopRendering();
 
     // Documentation inherited
     protected: virtual void mousePressEvent(QMouseEvent *_e) override;

--- a/src/plugins/minimal_scene/MinimalScene.qml
+++ b/src/plugins/minimal_scene/MinimalScene.qml
@@ -14,14 +14,16 @@
  * limitations under the License.
  *
 */
+import QtGraphicalEffects 1.0
 import QtQuick 2.9
 import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
 import RenderWindow 1.0
-import QtGraphicalEffects 1.0
 
 Rectangle {
-  width: 1000
-  height: 800
+  Layout.minimumWidth: 200
+  Layout.minimumHeight: 200
+  anchors.fill: parent
 
   /**
    * True to enable gamma correction
@@ -36,6 +38,7 @@ Rectangle {
     anchors.fill: parent
     hoverEnabled: true
     acceptedButtons: Qt.NoButton
+    visible: MinimalScene.loadingError.length == 0
     onEntered: {
       MinimalScene.OnFocusWindow()
     }
@@ -48,6 +51,7 @@ Rectangle {
     id: renderWindow
     objectName: "rw"
     anchors.fill: parent
+    visible: MinimalScene.loadingError.length == 0
   }
 
   /*
@@ -74,6 +78,14 @@ Rectangle {
 
   onDropped: {
     MinimalScene.OnDropped(drop.text, drag.x, drag.y)
+  }
+
+  Label {
+    anchors.fill: parent
+    anchors.margins: 10
+    text: MinimalScene.loadingError
+    visible: (MinimalScene.loadingError.length > 0);
+    wrapMode: Text.WordWrap
   }
 }
 }


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This is the same fix as the PRs below, applied to the `MinimalScene`.

* https://github.com/ignitionrobotics/ign-gui/pull/347
* https://github.com/ignitionrobotics/ign-gazebo/pull/1294

The `MinimalScene` required one extra detail. Because of all the render syncing going on, I had to explicitly shutdown the `RenderWindowItem` to stop all the connections from being fired.

![mini_boom](https://user-images.githubusercontent.com/5751272/156656858-89779d9f-5e0a-4843-b7e0-c061a74e6958.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
