### PR TITLE
TransportSceneManager: Prevent freeze when inserted from menu

### DIFF
--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -187,6 +187,8 @@ TransportSceneManager::TransportSceneManager()
 /////////////////////////////////////////////////
 TransportSceneManager::~TransportSceneManager()
 {
+  if (this->dataPtr->initializeTransport.joinable())
+    this->dataPtr->initializeTransport.join();
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -19,7 +19,10 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
+
+#include <QQmlProperty>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/MeshManager.hh>
@@ -44,6 +47,7 @@
 #endif
 
 #include <ignition/transport/Node.hh>
+#include <ignition/transport/TopicUtils.hh>
 
 #include "ignition/gui/Application.hh"
 #include "ignition/gui/Conversions.hh"
@@ -124,16 +128,16 @@ class ignition::gui::plugins::TransportSceneManagerPrivate
   public: void DeleteEntity(const unsigned int _entity);
 
   //// \brief Ign-transport scene service name
-  public: std::string service;
+  public: std::string service{"scene"};
 
   //// \brief Ign-transport pose topic name
-  public: std::string poseTopic;
+  public: std::string poseTopic{"pose"};
 
   //// \brief Ign-transport deletion topic name
-  public: std::string deletionTopic;
+  public: std::string deletionTopic{"delete"};
 
   //// \brief Ign-transport scene topic name
-  public: std::string sceneTopic;
+  public: std::string sceneTopic{"scene"};
 
   //// \brief Pointer to the rendering scene
   public: rendering::ScenePtr scene{nullptr};
@@ -165,6 +169,9 @@ class ignition::gui::plugins::TransportSceneManagerPrivate
   /// \brief Transport node for making service request and subscribing to
   /// pose topic
   public: ignition::transport::Node node;
+
+  /// \brief Thread to wait for transport initialization
+  public: std::thread initializeTransport;
 };
 
 using namespace ignition;
@@ -194,29 +201,56 @@ void TransportSceneManager::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     auto elem = _pluginElem->FirstChildElement("service");
     if (nullptr != elem && nullptr != elem->GetText())
     {
-      this->dataPtr->service = elem->GetText();
+      this->dataPtr->service =
+          transport::TopicUtils::AsValidTopic(elem->GetText());
     }
 
     elem = _pluginElem->FirstChildElement("pose_topic");
     if (nullptr != elem && nullptr != elem->GetText())
     {
-      this->dataPtr->poseTopic = elem->GetText();
+      this->dataPtr->poseTopic =
+          transport::TopicUtils::AsValidTopic(elem->GetText());
     }
 
     elem = _pluginElem->FirstChildElement("deletion_topic");
     if (nullptr != elem && nullptr != elem->GetText())
     {
-      this->dataPtr->deletionTopic = elem->GetText();
+      this->dataPtr->deletionTopic =
+          transport::TopicUtils::AsValidTopic(elem->GetText());
     }
 
     elem = _pluginElem->FirstChildElement("scene_topic");
     if (nullptr != elem && nullptr != elem->GetText())
     {
-      this->dataPtr->sceneTopic = elem->GetText();
+      this->dataPtr->sceneTopic =
+          transport::TopicUtils::AsValidTopic(elem->GetText());
     }
   }
 
-  App()->findChild<MainWindow *>()->installEventFilter(this);
+  QQmlProperty::write(this->PluginItem(), "service",
+      QString::fromStdString(this->dataPtr->service));
+  QQmlProperty::write(this->PluginItem(), "poseTopic",
+      QString::fromStdString(this->dataPtr->poseTopic));
+  QQmlProperty::write(this->PluginItem(), "deletionTopic",
+      QString::fromStdString(this->dataPtr->deletionTopic));
+  QQmlProperty::write(this->PluginItem(), "sceneTopic",
+      QString::fromStdString(this->dataPtr->sceneTopic));
+
+  if (this->dataPtr->service.empty() ||
+      this->dataPtr->poseTopic.empty() ||
+      this->dataPtr->deletionTopic.empty() ||
+      this->dataPtr->sceneTopic.empty())
+  {
+    ignerr << "One or more transport parameters invalid:" << std::endl
+        << "  * <service>: " << this->dataPtr->service << std::endl
+        << "  * <pose_topic>: " << this->dataPtr->poseTopic << std::endl
+        << "  * <deletion_topic>: " << this->dataPtr->deletionTopic << std::endl
+        << "  * <scene_topic>: " << this->dataPtr->sceneTopic << std::endl;
+  }
+  else
+  {
+    App()->findChild<MainWindow *>()->installEventFilter(this);
+  }
 }
 
 /////////////////////////////////////////////////
@@ -288,13 +322,14 @@ void TransportSceneManagerPrivate::Request()
     if (publishers.size() > 0)
       break;
     std::this_thread::sleep_for(sleepDuration);
-    igndbg << "Waiting for service " << this->service << "\n";
+    igndbg << "Waiting for service [" << this->service << "]\n";
   }
 
   if (publishers.empty() || !this->node.Request(this->service,
       &TransportSceneManagerPrivate::OnSceneSrvMsg, this))
   {
-    ignerr << "Error making service request to " << this->service << std::endl;
+    ignerr << "Error making service request to [" << this->service << "]"
+           << std::endl;
   }
 }
 
@@ -334,7 +369,8 @@ void TransportSceneManagerPrivate::OnRender()
     if (nullptr == this->scene)
       return;
 
-    this->InitializeTransport();
+    this->initializeTransport = std::thread(
+        &TransportSceneManagerPrivate::InitializeTransport, this);
   }
 
   std::lock_guard<std::mutex> lock(this->msgMutex);

--- a/src/plugins/transport_scene_manager/TransportSceneManager.hh
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.hh
@@ -36,10 +36,13 @@ namespace plugins
   /// ## Configuration
   ///
   /// * \<service\> : Name of service where this system will request a scene
-  ///                 message.
+  ///                 message. Optional, defaults to "/scene".
   /// * \<pose_topic\> : Name of topic to subscribe to receive pose updates.
+  ///                    Optional, defaults to "/pose".
   /// * \<deletion_topic\> : Name of topic to request entity deletions.
-  /// * \<scene_topic\> : Name of topic to receive scene updates.
+  ///                        Optional, defaults to "/delete".
+  /// * \<scene_topic\> : Name of topic to receive scene updates. Optional,
+  ///                     defaults to "/scene".
   class TransportSceneManager : public Plugin
   {
     Q_OBJECT

--- a/src/plugins/transport_scene_manager/TransportSceneManager.qml
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.qml
@@ -15,14 +15,37 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+GridLayout {
+  columns: 1
+  columnSpacing: 10
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 200
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string service: 'N/A'
+  property string poseTopic: 'N/A'
+  property string deletionTopic: 'N/A'
+  property string sceneTopic: 'N/A'
+
+  Label {
+    Layout.columnSpan: 1
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: "<b>Service</b>: " + service +
+          "<br><b>Pose topic</b>: " + poseTopic +
+          "<br><b>Deletion topic</b>: " + deletionTopic +
+          "<br><b>Scene topic</b>: " + sceneTopic
+  }
+
+
+  Item {
+    Layout.columnSpan: 1
+    width: 10
+    Layout.fillHeight: true
+  }
 }

--- a/src/plugins/transport_scene_manager/TransportSceneManager.qml
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.qml
@@ -36,10 +36,10 @@ GridLayout {
     Layout.columnSpan: 1
     Layout.fillWidth: true
     wrapMode: Text.WordWrap
-    text: "<b>Service</b>: " + service +
-          "<br><b>Pose topic</b>: " + poseTopic +
-          "<br><b>Deletion topic</b>: " + deletionTopic +
-          "<br><b>Scene topic</b>: " + sceneTopic
+    text: "<b>Service</b>: /" + service +
+          "<br><b>Pose topic</b>: /" + poseTopic +
+          "<br><b>Deletion topic</b>: /" + deletionTopic +
+          "<br><b>Scene topic</b>: /" + sceneTopic
   }
 
 

--- a/test/integration/transport_scene_manager.cc
+++ b/test/integration/transport_scene_manager.cc
@@ -162,6 +162,8 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
     QCoreApplication::processEvents();
     sleep++;
   }
+  EXPECT_TRUE(sceneRequested);
+  EXPECT_LT(sleep, maxSleep);
 
   auto scene = engine->SceneByName("banana");
   ASSERT_NE(nullptr, scene);
@@ -169,8 +171,15 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   auto root = scene->RootVisual();
   ASSERT_NE(nullptr, root);
 
+  for (sleep = 0; root->ChildCount() < 2 && sleep < maxSleep; ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    QCoreApplication::processEvents();
+  }
+  EXPECT_LT(sleep, maxSleep);
+
   // Check scene is populated
-  EXPECT_EQ(2u, root->ChildCount());
+  ASSERT_EQ(2u, root->ChildCount());
 
   // First child is user camera
   auto camera = std::dynamic_pointer_cast<rendering::Camera>(


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Currently, the `TransportSceneManager` freezes the window when inserted from the GUI menu, because it's waiting for an empty transport service for 30 seconds. With this PR:

* The service and other topics have default values, so the scene manager could potentially work when inserted
* The service and topics are displayed to the user, so they have an idea of what the plugin is trying to do
* The service request happens in a separate thread, so the rendering thread isn't blocked for 30 seconds
* If the user provides invalid topics, don't even subscribe to render events

![trans_manager](https://user-images.githubusercontent.com/5751272/156665363-6005df54-1939-4f13-9d42-cf892e88399e.gif)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
