### PR TITLE
Populate plugins that were empty

### DIFF
--- a/src/plugins/camera_tracking/CameraTracking.hh
+++ b/src/plugins/camera_tracking/CameraTracking.hh
@@ -30,6 +30,19 @@ namespace plugins
 {
   class CameraTrackingPrivate;
 
+  /// \brief This plugin provides camera tracking capabilities such as "move to"
+  /// and "follow".
+  ///
+  /// Services:
+  /// * `/gui/move_to`: Move the user camera to look at a given target,
+  ///                   identified by name.
+  /// * `/gui/move_to/pose`: Move the user camera to a given pose.
+  /// * `/gui/follow`: Set the user camera to follow a given target,
+  ///                   identified by name.
+  /// * `/gui/follow/offset`: Set the offset for following.
+  ///
+  /// Topics:
+  /// * `/gui/camera/pose`: Publishes the current user camera pose.
   class CameraTracking : public Plugin
   {
     Q_OBJECT

--- a/src/plugins/camera_tracking/CameraTracking.qml
+++ b/src/plugins/camera_tracking/CameraTracking.qml
@@ -21,7 +21,7 @@ import QtQuick.Layouts 1.3
 
 ColumnLayout {
   Layout.minimumWidth: 350
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 260
   anchors.fill: parent
   anchors.margins: 10
 

--- a/src/plugins/camera_tracking/CameraTracking.qml
+++ b/src/plugins/camera_tracking/CameraTracking.qml
@@ -15,14 +15,31 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 200
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: 'Services provided:<br><ul>' +
+      '<li>/gui/move_to</li>' +
+      '<li>/gui/move_to/pose</li>' +
+      '<li>/gui/follow</li>' +
+      '<li>/gui/follow/offset</li></ul><br>Topics provided:<br><ul>' +
+      '<li>/gui/camera/pose</li></ul>'
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
+  }
 }

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -258,6 +258,9 @@ InteractiveViewControl::~InteractiveViewControl() = default;
 void InteractiveViewControl::LoadConfig(
   const tinyxml2::XMLElement * /*_pluginElem*/)
 {
+  if (this->title.empty())
+    this->title = "Interactive view control";
+
   // camera view control mode
   this->dataPtr->cameraViewControlService = "/gui/camera/view_control";
   this->dataPtr->node.Advertise(this->dataPtr->cameraViewControlService,

--- a/src/plugins/interactive_view_control/InteractiveViewControl.qml
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.qml
@@ -21,7 +21,7 @@ import QtQuick.Layouts 1.3
 
 ColumnLayout {
   Layout.minimumWidth: 350
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 110
   anchors.fill: parent
   anchors.margins: 10
 

--- a/src/plugins/interactive_view_control/InteractiveViewControl.qml
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.qml
@@ -15,14 +15,27 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 200
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string message: '<ul><li>Adding mouse controls to the 3D scene.</li>' +
+      '<li>Providing the /gui/camera/view_control service</li></ul>'
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
+  }
 }

--- a/src/plugins/marker_manager/MarkerManager.hh
+++ b/src/plugins/marker_manager/MarkerManager.hh
@@ -37,8 +37,8 @@ namespace plugins
   ///
   /// * `<topic_name>`: Optional. Name of topic for marker service. Defaults
   /// to `/marker`.
-  /// * `<stats_topic>`: Optional. Name of topic to receive world stats. Defaults
-  /// to `/world/[world name]/stats`.
+  /// * `<stats_topic>`: Optional. Name of topic to receive world stats.
+  /// Defaults to `/world/[world name]/stats`.
   /// * `<warn_on_action_failure>`: True to display warnings if the user
   /// attempts to perform an invalid action. Defaults to true.
   class MarkerManager : public Plugin

--- a/src/plugins/marker_manager/MarkerManager.hh
+++ b/src/plugins/marker_manager/MarkerManager.hh
@@ -30,13 +30,15 @@ namespace plugins
 {
   class MarkerManagerPrivate;
 
-  /// \brief This plugin will be in charge of handeling the markers in the
+  /// \brief This plugin will be in charge of handling the markers in the
   /// scene. It will allow to add, modify or remove markers.
   ///
   /// ## Parameters
   ///
-  /// * `<topic_name>`: Options. Name of topic for marker service. Defaults
+  /// * `<topic_name>`: Optional. Name of topic for marker service. Defaults
   /// to `/marker`.
+  /// * `<stats_topic>`: Optional. Name of topic to receive world stats. Defaults
+  /// to `/world/[world name]/stats`.
   /// * `<warn_on_action_failure>`: True to display warnings if the user
   /// attempts to perform an invalid action. Defaults to true.
   class MarkerManager : public Plugin

--- a/src/plugins/marker_manager/MarkerManager.qml
+++ b/src/plugins/marker_manager/MarkerManager.qml
@@ -15,14 +15,33 @@
  *
 */
 
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-// TODO: remove invisible rectangle, see
-// https://github.com/ignitionrobotics/ign-gui/issues/220
-Rectangle {
-  visible: false
-  Layout.minimumWidth: 100
-  Layout.minimumHeight: 100
+ColumnLayout {
+  Layout.minimumWidth: 350
+  Layout.minimumHeight: 200
+  anchors.fill: parent
+  anchors.margins: 10
+
+  property string topicName: ''
+  property string statsTopic: ''
+
+  property string message: 'Services provided:<br><ul>' +
+      '<li>' + topicName + '</li>' +
+      '<li>' + topicName + '_array</li>' +
+      '<li>' + topicName + '/list</li></ul><br>Topics subscribed:<br><ul>' +
+      '<li>' + statsTopic + '</li></ul>'
+
+  Label {
+    Layout.fillWidth: true
+    wrapMode: Text.WordWrap
+    text: message
+  }
+
+  Item {
+    width: 10
+    Layout.fillHeight: true
+  }
 }

--- a/src/plugins/marker_manager/MarkerManager.qml
+++ b/src/plugins/marker_manager/MarkerManager.qml
@@ -21,7 +21,7 @@ import QtQuick.Layouts 1.3
 
 ColumnLayout {
   Layout.minimumWidth: 350
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 230
   anchors.fill: parent
   anchors.margins: 10
 


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1254

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Populate plugins that were previously empty so that users aren't too confused when inserting them from the menu.

![image](https://user-images.githubusercontent.com/5751272/156689895-9383fa2d-fe9a-44ad-8fa4-81277d7066c2.png)

### CameraTracking

Besides displaying message: 

* Add top-level plugin docs

### InteractiveViewControl

Besides displaying message: 

* Add plugin title

### MarkerManager

Besides displaying message: 

* Make sure `stats_topic` works even when there's no `_pluginElem` 
* Update docs

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
