### PR TITLE
Added Snackbar qtquick object

### DIFF
--- a/include/ignition/gui/qml/IgnSnackBar.qml
+++ b/include/ignition/gui/qml/IgnSnackBar.qml
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import QtQuick.Window 2.2
+import QtQuick.Dialogs 1.0
+
+Dialog {
+  id: snackbar
+  modal: true
+  focus: true
+  x: (window.width - width) / 2
+  y: window.height - window.height / 6
+  width: window.width - window.width / 6
+  contentHeight: notificationColumn.height
+
+  property int duration: 1000
+  property bool persistant: false
+
+  function setText(_message) {
+    notificationText.text = _message
+    if (!persistant)
+      timer.restart()
+  }
+
+  Column {
+    id: notificationColumn
+    spacing: 20
+
+    Label {
+      id: notificationText
+      width: snackbar.availableWidth
+      wrapMode: Label.Wrap
+      font.pixelSize: 18
+    }
+  }
+  Timer {
+      id: timer
+      interval: snackbar.duration
+      onTriggered: {
+          if (!running) {
+              snackbar.close();
+          }
+      }
+  }
+}

--- a/include/ignition/gui/qml/Main.qml
+++ b/include/ignition/gui/qml/Main.qml
@@ -102,7 +102,7 @@ ApplicationWindow
   Connections {
     target: MainWindow
     onNotify: {
-      notificationText.text = _message
+      notificationDialog.setText(_message)
       notificationDialog.open()
     }
   }
@@ -319,29 +319,9 @@ ApplicationWindow
     }
   }
 
-  /**
-   * TODO: change to a snackbar / toast
-   */
-  Dialog {
+  IgnSnackBar {
     id: notificationDialog
-    modal: true
-    focus: true
-    x: (window.width - width) / 2
-    y: window.height / 6
-    width: Math.min(window.width, window.height) / 3 * 2
-    contentHeight: notificationColumn.height
-
-    Column {
-      id: notificationColumn
-      spacing: 20
-
-      Label {
-        id: notificationText
-        width: notificationDialog.availableWidth
-        wrapMode: Label.Wrap
-        font.pixelSize: 18
-      }
-    }
+    persistant: true
   }
 
   Timer {

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -9,6 +9,7 @@
   <file>qml/IgnRulers.qml</file>
   <file>qml/IgnSortFilterModel.qml</file>
   <file>qml/IgnSpinBox.qml</file>
+  <file>qml/IgnSnackBar.qml</file>
   <file>qml/IgnSplit.qml</file>
   <file>qml/Main.qml</file>
   <file>qml/PlottingInterface.qml</file>
@@ -28,5 +29,6 @@
     <file alias="qmldir">qml/qmldir</file>
     <!-- Add any QML components referenced in the qmldir file here -->
     <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
+    <file alias="IgnSnackBar.qml">qml/IgnSnackBar.qml</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🎉 New feature

Related with this issue https://github.com/ignitionrobotics/ign-gui/issues/44

## Summary

Create a IgnSnackBar QtQuick object to show message to the user in the same manner by plugins

It could be :
 - persistant and then you need to click inside the GUI
 - or with a timeout

![snackbar](https://user-images.githubusercontent.com/1933907/156821311-5fd70097-f47f-4701-b680-e5bcf1d123fd.gif)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
