### PR TITLE
Fix menu scrolling when a new plugin is added

### DIFF
--- a/include/ignition/gui/qml/IgnSplit.qml
+++ b/include/ignition/gui/qml/IgnSplit.qml
@@ -280,10 +280,10 @@ SplitView {
           return;
 
         // Propagate child's minimum size changes to the item.
-        Layout.minimumWidth = Qt.binding(function() {
+        newItem.Layout.minimumWidth = Qt.binding(function() {
           return children[0].Layout.minimumWidth
         });
-        Layout.minimumHeight = Qt.binding(function() {
+        newItem.Layout.minimumHeight = Qt.binding(function() {
           return children[0].Layout.minimumHeight
         });
       }
@@ -357,8 +357,9 @@ SplitView {
                 Layout.minimumWidth = child.Layout.minimumWidth;
               }
               heightSum += child.height;
-              minHeightSum += child.height < child.Layout.minimumHeight ?
-                  child.height : child.Layout.minimumHeight;
+
+              var collapsed = child.Layout.maximumHeight == 50
+              minHeightSum += collapsed ? child.height : child.Layout.minimumHeight
             }
 
             // Minimum height to show all children

--- a/include/ignition/gui/qml/IgnSplit.qml
+++ b/include/ignition/gui/qml/IgnSplit.qml
@@ -276,14 +276,15 @@ SplitView {
        * Callback when the children array has been changed.
        */
       onChildrenChanged: {
-        if (children.length === 0)
-          return;
-
         // Propagate child's minimum size changes to the item.
         newItem.Layout.minimumWidth = Qt.binding(function() {
+          if (children.length === 0 || children[0] === undefined)
+            return 0;
           return children[0].Layout.minimumWidth
         });
         newItem.Layout.minimumHeight = Qt.binding(function() {
+          if (children.length === 0 || children[0] === undefined)
+            return 0;
           return children[0].Layout.minimumHeight
         });
       }


### PR DESCRIPTION
# 🦟 Bug fix

* Closes https://github.com/ignitionrobotics/ign-gui/issues/200

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Scrolling the right split has been broken since #194. It only took me a year to come back and fix it :upside_down_face: 

There were 2 issues:

* The scope when setting `Layout.minimumWidth`
* The logic meant to check if an item is collapsed was using its current height, instead of its `Layout.maximumHeight`

I hope I'm not introducing yet another bug. I think all use cases mentioned in #194 are covered here, but I'd appreciate if the reviewers really try to break this.

![split_scroll](https://user-images.githubusercontent.com/5751272/156849969-737a5d6b-efc3-4627-b0cf-3830afcd867d.gif)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
