### PR TITLE
Remove Bionic from future releases (Garden+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,6 @@ name: Ubuntu CI
 on: [push, pull_request]
 
 jobs:
-  bionic-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Bionic CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Compile and test
-        id: ci
-        uses: ignition-tooling/action-ignition-ci@bionic
-        with:
-          codecov-enabled: true
-          doxygen-enabled: true
   focal-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Focal CI
@@ -24,3 +12,6 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
+        with:
+          codecov-enabled: true
+          doxygen-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,6 @@ jobs:
         uses: ignition-tooling/action-ignition-ci@focal
         with:
           codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
           doxygen-enabled: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Build | Status
 -- | --
 Test coverage | [![codecov](https://codecov.io/gh/ignitionrobotics/ign-gui/branch/main/graph/badge.svg)](https://codecov.io/gh/ignitionrobotics/ign-gui/branch/main)
-Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-main-bionic-amd64)](https://build.osrfoundation.org/job/ignition_gui-ci-main-bionic-amd64)
+Ubuntu Focal | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-main-focal-amd64)](https://build.osrfoundation.org/job/ignition_gui-ci-main-focal-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_gui-ci-main-homebrew-amd64)
 Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gui-ci-win)](https://build.osrfoundation.org/job/ign_gui-ci-win)
 

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -58,7 +58,7 @@ Binary install is pending `ignition-rendering` and `ignition-gui` being added to
 
 ## Source Install
 
-### Ubuntu Bionic 18.04 or above
+### Ubuntu Focal 20.04 or above
 
 #### Install Prerequisites
 
@@ -80,11 +80,6 @@ Clone source code:
 Install dependencies
   ```
   sudo apt -y install $(sort -u $(find . -iname 'packages.apt') | tr '\n' ' ')
-  ```
-
-Only on Bionic, update the GCC compiler version:
-  ```
-  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
   ```
 
 #### Build from source


### PR DESCRIPTION
* See https://github.com/ignition-tooling/release-tools/issues/597

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

`ign-gui7` will be on Garden.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

No Bionic builds should be triggered.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
