### PR TITLE
Fix nondiscard warnings with lock_guard

### DIFF
--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -144,7 +144,7 @@ void PointCloud::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 //////////////////////////////////////////////////
 void PointCloud::OnPointCloudTopic(const QString &_pointCloudTopic)
 {
-  std::lock_guard<std::recursive_mutex>(this->dataPtr->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
   // Unsubscribe from previous choice
   if (!this->dataPtr->pointCloudTopic.empty() &&
       !this->dataPtr->node.Unsubscribe(this->dataPtr->pointCloudTopic))
@@ -176,7 +176,7 @@ void PointCloud::OnPointCloudTopic(const QString &_pointCloudTopic)
 //////////////////////////////////////////////////
 void PointCloud::OnFloatVTopic(const QString &_floatVTopic)
 {
-  std::lock_guard<std::recursive_mutex>(this->dataPtr->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
   // Unsubscribe from previous choice
   if (!this->dataPtr->floatVTopic.empty() &&
       !this->dataPtr->node.Unsubscribe(this->dataPtr->floatVTopic))
@@ -222,7 +222,7 @@ void PointCloud::Show(bool _show)
 /////////////////////////////////////////////////
 void PointCloud::OnRefresh()
 {
-  std::lock_guard<std::recursive_mutex>(this->dataPtr->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
   ignmsg << "Refreshing topic list for point cloud messages." << std::endl;
 
   // Clear
@@ -296,7 +296,7 @@ void PointCloud::SetFloatVTopicList(
 void PointCloud::OnPointCloud(
     const ignition::msgs::PointCloudPacked &_msg)
 {
-  std::lock_guard<std::recursive_mutex>(this->dataPtr->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
   this->dataPtr->pointCloudMsg = _msg;
   this->dataPtr->PublishMarkers();
 }
@@ -304,7 +304,7 @@ void PointCloud::OnPointCloud(
 //////////////////////////////////////////////////
 void PointCloud::OnFloatV(const ignition::msgs::Float_V &_msg)
 {
-  std::lock_guard<std::recursive_mutex>(this->dataPtr->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
   this->dataPtr->floatVMsg = _msg;
 
   this->dataPtr->minFloatV = std::numeric_limits<float>::max();
@@ -365,7 +365,7 @@ void PointCloudPrivate::PublishMarkers()
     return;
   }
 
-  std::lock_guard<std::recursive_mutex>(this->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->mutex);
   ignition::msgs::Marker marker;
   marker.set_ns(this->pointCloudTopic + this->floatVTopic);
   marker.set_id(1);
@@ -429,7 +429,7 @@ void PointCloudPrivate::ClearMarkers()
   if (this->pointCloudTopic.empty())
     return;
 
-  std::lock_guard<std::recursive_mutex>(this->mutex);
+  std::lock_guard<std::recursive_mutex> lock(this->mutex);
   ignition::msgs::Marker msg;
   msg.set_ns(this->pointCloudTopic + this->floatVTopic);
   msg.set_id(0);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Clean up Windows warnings.

I changed to keeping the object instead of discarding it, let's see if that's enough. This pattern is used on other plugins already.

The original line:

`std::lock_guard<std::mutex>(this->dataPtr->mutex)`

Was creating an object but not holding it. This would be a way to keep it within the function's scope:

`auto lock = std::lock_guard<std::mutex>(this->dataPtr->mutex)`

I think some compilers may call a constructor, and then a copy operator that way. So I chose to go with the following, which only calls the constructor:

`std::lock_guard<std::mutex> lock(this->dataPtr->mutex)`

Let me know what you think, @jennuine .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
