### PR TITLE
Fix some Qt warnings

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -89,6 +89,10 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
 {
   igndbg << "Initializing application." << std::endl;
 
+  this->setOrganizationName("Ignition");
+  this->setOrganizationDomain("ignitionrobotics.org");
+  this->setApplicationName("Ignition GUI");
+
   // Configure console
   common::Console::SetPrefix("[GUI] ");
 

--- a/src/plugins/world_control/WorldControl.qml
+++ b/src/plugins/world_control/WorldControl.qml
@@ -91,7 +91,7 @@ RowLayout {
     visible: showPlay
     text: paused ? playIcon : pauseIcon
     checkable: true
-    anchors.verticalCenter: parent.verticalCenter
+    Layout.alignment : Qt.AlignVCenter
     Layout.minimumWidth: width
     Layout.leftMargin: 10
     onClicked: {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Fix these warnings:

`[ign-8] [GUI] [Wrn] [Application.cc:649] [QT] file::/WorldControl/WorldControl.qml:88:3: QML RoundButton: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.`

and 

```
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: Failed to initialize QSettings instance. Status code is: 1
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: The following application identifiers have not been set: QVector("organizationName", "organizationDomain")
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: Failed to initialize QSettings instance. Status code is: 1
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: The following application identifiers have not been set: QVector("organizationName", "organizationDomain")
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: Failed to initialize QSettings instance. Status code is: 1
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: The following application identifiers have not been set: QVector("organizationName", "organizationDomain")
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: Failed to initialize QSettings instance. Status code is: 1
[GUI] [Wrn] [Application.cc:753] [QT] file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Dialogs/DefaultFileDialog.qml:102:33: QML Settings: The following application identifiers have not been set: QVector("organizationName", "organizationDomain")
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
