### PR TITLE
Avoid nullptr access in MinimalScene

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -559,6 +559,11 @@ std::string IgnRenderer::Initialize()
 
   igndbg << "Create scene [" << this->sceneName << "]" << std::endl;
   auto scene = engine->CreateScene(this->sceneName);
+  if (nullptr == scene)
+  {
+    return "Failed to create scene [" + this->sceneName + "] for engine [" +
+        this->engineName + "]";
+  }
   scene->SetAmbientLight(this->ambientLight);
   scene->SetBackgroundColor(this->backgroundColor);
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While debugging a problem in `ign-rendering`, I noticed that we may access a null scene here. So just guard against that.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
