### PR TITLE
[ign to gz] Deprecate IGN_GUI_PLUGIN_PATH in favor of GZ_GUI_PLUGIN_PATH

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,10 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition GUI 6.X to 7.X
+
+* The environment variable `IGN_GUI_PLUGIN_PATH` is deprecated. Use `GZ_GUI_PLUGIN_PATH` instead.
+
 ## Ignition GUI 6.2 to 6.3
 
 * New QML dependencies, only needed for the NavSatMap plugin: `qml-module-qtlocation`, `qml-module-qtpositioning`

--- a/examples/plugin/custom_context_menu/README.md
+++ b/examples/plugin/custom_context_menu/README.md
@@ -10,10 +10,10 @@
 Standalone
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -s CustomContext
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -s CustomContext
 
 Or open an empty window and insert from menu
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui
     # Choose CustomContext from menu

--- a/examples/plugin/dialog_from_plugin/README.md
+++ b/examples/plugin/dialog_from_plugin/README.md
@@ -13,10 +13,10 @@ a modal dialog attached to the main window from a plugin.
 Standalone
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -s DialogFromPlugin
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -s DialogFromPlugin
 
 Or open an empty window and insert from menu
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui
     # Choose DialogFromPlugin from menu

--- a/examples/plugin/hello_plugin/README.md
+++ b/examples/plugin/hello_plugin/README.md
@@ -13,16 +13,16 @@ configuration from XML.
 Standalone:
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -s HelloPlugin
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -s HelloPlugin
 
 Within a window where other plugins can also be inserted, using a custom
 configuration:
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -c ../HelloPlugin.config
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -c ../HelloPlugin.config
 
 Or open an empty window and insert from menu:
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui
     # Choose HelloPlugin from menu

--- a/examples/plugin/ign_components/README.md
+++ b/examples/plugin/ign_components/README.md
@@ -13,11 +13,11 @@ useful for downstream developers.
 Standalone:
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -s IgnComponents
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -s IgnComponents
 
 Within a window where other plugins can also be inserted, using a custom
 configuration:
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -c ../IgnComponents.config
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -c ../IgnComponents.config
 

--- a/examples/plugin/multiple_qml/README.md
+++ b/examples/plugin/multiple_qml/README.md
@@ -12,5 +12,5 @@ This example shows how to compose a single plugin from multiple QML files.
 Quickly check try your plugin as follows:
 
     cd build
-    export IGN_GUI_PLUGIN_PATH=`pwd`; ign gui -s MultipleQml
+    export GZ_GUI_PLUGIN_PATH=`pwd`; ign gui -s MultipleQml
 

--- a/tutorials/03_plugins.md
+++ b/tutorials/03_plugins.md
@@ -17,7 +17,7 @@ for an example.
 
 Ignition GUI will look for plugins on the following paths, in this order:
 
-1. All paths set on the `IGN_GUI_PLUGIN_PATH` environment variable
+1. All paths set on the `GZ_GUI_PLUGIN_PATH` environment variable
 2. All paths added by calling `ignition::gui::addPluginPath`
 3. `~/.ignition/gui/plugins`
 4. [Plugins which are installed with Ignition GUI](https://ignitionrobotics.org/api/gui/6.0/namespaceignition_1_1gui_1_1plugins.html)


### PR DESCRIPTION
# 🎉 New feature

* Part of https://github.com/ignition-tooling/release-tools/issues/698

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Rename the environment variable with a tick-tock cycle.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Try out the `hello_plugin`in `examples/plugin/hello_plugin`:

```
$ GZ_GUI_PLUGIN_PATH=`pwd`/build ign gui -s HelloPlugin -v 2
# Loads the plugin without warnings.
```

```
$ IGN_GUI_PLUGIN_PATH=`pwd`/build ign gui -s HelloPlugin -v 2
[GUI] [Wrn] [Application.cc:454] Found plugin [HelloPlugin] using deprecated environment variable [IGN_GUI_PLUGIN_PATH]. Please use [GZ_GUI_PLUGIN_PATH] instead.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
