### PR TITLE
Add config relative path environment variable

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -231,9 +231,9 @@ bool Application::LoadConfig(const std::string &_config)
   // It will be created the first time the user presses "Save configuration".)
   if (!common::exists(configFull) && (configFull != this->DefaultConfigPath()))
   {
-    // If not, then check the IGN_GUI_RESOURCE_PATH environment variable
+    // If not, then check environment variable
     std::string configPathEnv;
-    common::env("IGN_GUI_RESOURCE_PATH", configPathEnv);
+    common::env("GZ_GUI_RESOURCE_PATH", configPathEnv);
 
     if (!configPathEnv.empty())
     {

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -19,7 +19,9 @@
 #include <queue>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
 #include <ignition/common/SignalHandler.hh>
+#include <ignition/common/StringUtils.hh>
 #include <ignition/common/SystemPaths.hh>
 #include <ignition/common/Util.hh>
 
@@ -222,24 +224,50 @@ bool Application::LoadConfig(const std::string &_config)
     return false;
   }
 
+  std::string configFull = _config;
+
+  // Check if the passed in config file exists.
+  // (If the default config path doesn't exist yet, it's expected behavior.
+  // It will be created the first time the user presses "Save configuration".)
+  if (!common::exists(configFull) && (configFull != this->DefaultConfigPath()))
+  {
+    // If not, then check the IGN_GUI_RESOURCE_PATH environment variable
+    std::string configPathEnv;
+    common::env("IGN_GUI_RESOURCE_PATH", configPathEnv);
+
+    if (!configPathEnv.empty())
+    {
+      std::vector<std::string> parentPaths = common::Split(configPathEnv, ':');
+      for (auto parentPath : parentPaths)
+      {
+        std::string tempPath = common::joinPaths(parentPath, configFull);
+        if (common::exists(tempPath))
+        {
+          configFull = tempPath;
+          break;
+        }
+      }
+    }
+  }
+
   // Use tinyxml to read config
   tinyxml2::XMLDocument doc;
-  auto success = !doc.LoadFile(_config.c_str());
+  auto success = !doc.LoadFile(configFull.c_str());
   if (!success)
   {
     // We do not show an error message if the default config path doesn't exist
     // yet. It's expected behavior, it will be created the first time the user
     // presses "Save configuration".
-    if (_config != this->DefaultConfigPath())
+    if (configFull != this->DefaultConfigPath())
     {
-      ignerr << "Failed to load file [" << _config << "]: XMLError"
+      ignerr << "Failed to load file [" << configFull << "]: XMLError"
              << std::endl;
     }
 
     return false;
   }
 
-  ignmsg << "Loading config [" << _config << "]" << std::endl;
+  ignmsg << "Loading config [" << configFull << "]" << std::endl;
 
   // Clear all previous plugins
   auto plugins = this->dataPtr->mainWin->findChildren<Plugin *>();

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -180,16 +180,16 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadConfig))
     EXPECT_FALSE(app.LoadConfig("ignore.config"));
 
     // Invalid path
-    setenv("IGN_GUI_RESOURCE_PATH", "invalidPath", 1);
+    setenv("GZ_GUI_RESOURCE_PATH", "invalidPath", 1);
     EXPECT_FALSE(app.LoadConfig("ignore.config"));
 
     // Valid path
-    setenv("IGN_GUI_RESOURCE_PATH",
+    setenv("GZ_GUI_RESOURCE_PATH",
         (std::string(PROJECT_SOURCE_PATH) + "/test/config").c_str(), 1);
     EXPECT_TRUE(app.LoadConfig("ignore.config"));
 
     // Multiple paths, one valid
-    setenv("IGN_GUI_RESOURCE_PATH",
+    setenv("GZ_GUI_RESOURCE_PATH",
         ("banana:" + std::string(PROJECT_SOURCE_PATH) + "/test/config" +
         ":orange").c_str(), 1);
     EXPECT_TRUE(app.LoadConfig("ignore.config"));

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -172,6 +172,28 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LoadConfig))
     auto testSourcePath = std::string(PROJECT_SOURCE_PATH) + "/test/";
     EXPECT_TRUE(app.LoadConfig(testSourcePath + "config/test.config"));
   }
+
+  // Test environment variable and relative path
+  {
+    // Environment variable not set
+    Application app(g_argc, g_argv);
+    EXPECT_FALSE(app.LoadConfig("ignore.config"));
+
+    // Invalid path
+    setenv("IGN_GUI_RESOURCE_PATH", "invalidPath", 1);
+    EXPECT_FALSE(app.LoadConfig("ignore.config"));
+
+    // Valid path
+    setenv("IGN_GUI_RESOURCE_PATH",
+        (std::string(PROJECT_SOURCE_PATH) + "/test/config").c_str(), 1);
+    EXPECT_TRUE(app.LoadConfig("ignore.config"));
+
+    // Multiple paths, one valid
+    setenv("IGN_GUI_RESOURCE_PATH",
+        ("banana:" + std::string(PROJECT_SOURCE_PATH) + "/test/config" +
+        ":orange").c_str(), 1);
+    EXPECT_TRUE(app.LoadConfig("ignore.config"));
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/cmd/cmdgui.rb.in
+++ b/src/cmd/cmdgui.rb.in
@@ -182,8 +182,48 @@ class Cmd
             Importer.extern 'void cmdStandalone(const char *)'
             Importer.cmdStandalone(options['standalone'])
           elsif options.key?('config')
+
+            # Check if the passed in config file exists.
+            if File.exists?(options['config'])
+              path = options['config']
+            # If not, then first check the IGN_GUI_CONFIG_PATH environment
+            # variable, then IGN_GUI_RESOURCES.
+            else
+              configPathEnv = ENV['IGN_GUI_CONFIG_PATH']
+              if !configPathEnv.nil?
+                configPaths = configPathEnv.split(':')
+                for configPath in configPaths
+                  filePath = File.join(configPath, options['config'])
+                  if File.exists?(filePath)
+                    path = filePath
+                    break
+                  end
+                end
+              end
+
+              if path.nil?
+                resourcePathEnv = ENV['IGN_GUI_RESOURCES']
+                if !resourcePathEnv.nil?
+                  resourcePaths = resourcePathEnv.split(':')
+                  for resourcePath in resourcePaths
+                    filePath = File.join(resourcePath, options['config'])
+                    if File.exists?(filePath)
+                      path = filePath
+                      break
+                    end
+                  end
+                end
+              end
+
+              if path.nil?
+                puts "Unable to find config file " + options['config']
+                exit(-1)
+              end
+            end
+
             Importer.extern 'void cmdConfig(const char *)'
-            Importer.cmdConfig(options['config'])
+            Importer.cmdConfig(path)
+
           elsif options.key?('emptywindow')
             Importer.extern 'void cmdEmptyWindow()'
             Importer.cmdEmptyWindow()

--- a/src/cmd/cmdgui.rb.in
+++ b/src/cmd/cmdgui.rb.in
@@ -54,7 +54,7 @@ COMMANDS = {  'gui' =>
                        "\n" +
                        COMMON_OPTIONS + "\n\n" +
                        "Environment variables:                                                  \n"\
-                       "  IGN_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI     \n"\
+                       "  GZ_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI     \n"\
                        " resources such as configuration files.                                 \n"\
             }
 

--- a/src/cmd/cmdgui.rb.in
+++ b/src/cmd/cmdgui.rb.in
@@ -52,7 +52,10 @@ COMMANDS = {  'gui' =>
                        "                             The default verbosity is 1, use -v without\n"\
                        "                             arguments for level 3.\n"\
                        "\n" +
-                       COMMON_OPTIONS,
+                       COMMON_OPTIONS + "\n\n" +
+                       "Environment variables:                                                  \n"\
+                       "  IGN_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI     \n"\
+                       " resources such as configuration files.                                 \n"\
             }
 
 #

--- a/src/cmd/cmdgui.rb.in
+++ b/src/cmd/cmdgui.rb.in
@@ -182,48 +182,8 @@ class Cmd
             Importer.extern 'void cmdStandalone(const char *)'
             Importer.cmdStandalone(options['standalone'])
           elsif options.key?('config')
-
-            # Check if the passed in config file exists.
-            if File.exists?(options['config'])
-              path = options['config']
-            # If not, then first check the IGN_GUI_CONFIG_PATH environment
-            # variable, then IGN_GUI_RESOURCES.
-            else
-              configPathEnv = ENV['IGN_GUI_CONFIG_PATH']
-              if !configPathEnv.nil?
-                configPaths = configPathEnv.split(':')
-                for configPath in configPaths
-                  filePath = File.join(configPath, options['config'])
-                  if File.exists?(filePath)
-                    path = filePath
-                    break
-                  end
-                end
-              end
-
-              if path.nil?
-                resourcePathEnv = ENV['IGN_GUI_RESOURCES']
-                if !resourcePathEnv.nil?
-                  resourcePaths = resourcePathEnv.split(':')
-                  for resourcePath in resourcePaths
-                    filePath = File.join(resourcePath, options['config'])
-                    if File.exists?(filePath)
-                      path = filePath
-                      break
-                    end
-                  end
-                end
-              end
-
-              if path.nil?
-                puts "Unable to find config file " + options['config']
-                exit(-1)
-              end
-            end
-
             Importer.extern 'void cmdConfig(const char *)'
-            Importer.cmdConfig(path)
-
+            Importer.cmdConfig(options['config'])
           elsif options.key?('emptywindow')
             Importer.extern 'void cmdEmptyWindow()'
             Importer.cmdEmptyWindow()

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -96,3 +96,30 @@ TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
   EXPECT_TRUE(common::exists(common::joinPaths(this->kFakeHome, ".ignition",
       "gui")));
 }
+
+/////////////////////////////////////////////////
+TEST_F(CmdLine, ConfigPath)
+{
+  std::string cmd = "ign gui --config style.config";
+
+  // No path
+  std::string output = custom_exec_str(cmd);
+  EXPECT_NE(output.find("Unable to find config file style.config"),
+      std::string::npos) << output;
+
+  // Correct path
+  auto path = std::string("IGN_GUI_CONFIG_PATH=") +
+    PROJECT_SOURCE_PATH + "/examples/config ";
+
+  output = custom_exec_str(path + cmd);
+  EXPECT_EQ(output.find("Unable to find config file style.config"),
+      std::string::npos) << output;
+
+  // Several paths
+  path = std::string("IGN_GUI_RESOURCES=banana:") +
+    PROJECT_SOURCE_PATH + "/examples/config:orange ";
+
+  output = custom_exec_str(path + cmd);
+  EXPECT_EQ(output.find("Unable to find config file style.config"),
+      std::string::npos) << output;
+}

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -107,6 +107,7 @@ TEST_F(CmdLine, ConfigPath)
   EXPECT_NE(output.find("Unable to find config file style.config"),
       std::string::npos) << output;
 
+  /* Need to find a way to close window automatically
   // Correct path
   auto path = std::string("IGN_GUI_CONFIG_PATH=") +
     PROJECT_SOURCE_PATH + "/examples/config ";
@@ -122,4 +123,5 @@ TEST_F(CmdLine, ConfigPath)
   output = custom_exec_str(path + cmd);
   EXPECT_EQ(output.find("Unable to find config file style.config"),
       std::string::npos) << output;
+  */
 }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -96,32 +96,3 @@ TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
   EXPECT_TRUE(common::exists(common::joinPaths(this->kFakeHome, ".ignition",
       "gui")));
 }
-
-/////////////////////////////////////////////////
-TEST_F(CmdLine, ConfigPath)
-{
-  std::string cmd = "ign gui --config style.config";
-
-  // No path
-  std::string output = custom_exec_str(cmd);
-  EXPECT_NE(output.find("Unable to find config file style.config"),
-      std::string::npos) << output;
-
-  /* Need to find a way to close window automatically
-  // Correct path
-  auto path = std::string("IGN_GUI_CONFIG_PATH=") +
-    PROJECT_SOURCE_PATH + "/examples/config ";
-
-  output = custom_exec_str(path + cmd);
-  EXPECT_EQ(output.find("Unable to find config file style.config"),
-      std::string::npos) << output;
-
-  // Several paths
-  path = std::string("IGN_GUI_RESOURCES=banana:") +
-    PROJECT_SOURCE_PATH + "/examples/config:orange ";
-
-  output = custom_exec_str(path + cmd);
-  EXPECT_EQ(output.find("Unable to find config file style.config"),
-      std::string::npos) << output;
-  */
-}

--- a/tutorials/07_config.md
+++ b/tutorials/07_config.md
@@ -15,9 +15,19 @@ By default, Ignition GUI will load the config file at
 Configuration files can also be loaded from the command line or through the
 C++ API.
 
-From the command line, use the `--config` / `-c` option, for example:
+From the command line, use the `--config` / `-c` option.
+For example, you can specify an absolute path:
 
-`ign gui -c path/to/example.config`
+`ign gui -c /absolute/path/to/example.config`
+
+Or a path relative to the current working directory:
+
+`ign gui -c relative/path/to/example.config`
+
+Or a path relative to a custom directory, which you can specify by setting the
+environment variable `GZ_GUI_RESOURCE_PATH`, like so:
+
+`GZ_GUI_RESOURCE_PATH=/absolute/path/to/ ign gui --config example.config`
 
 From the C++ API, pass the file path to
 [Application::LoadConfig](https://ignitionrobotics.org/api/gui/3.0/classignition_1_1gui_1_1Application.html#a03c4c3a1b1e58cc4bff05658f21fff17).


### PR DESCRIPTION
# 🎉 New feature

Closes #337

## Summary

Before trying to load the `--config` path, check environment variable `GZ_GUI_RESOURCE_PATH`.
This allows relative config paths with respect to those environment variables to be specified after `--config`.

Implementation similar to `ign-gazebo` https://github.com/ignitionrobotics/ign-gazebo/blob/b825c27841f38c1df06cd053f70f9836786b590d/src/cmd/cmdgazebo.rb.in#L393-L409 but in C++ instead of Ruby.

~~Questions:~~

~~- Do we want both variables? Are those the final names we want? The ign-gazebo env var name is `IGN_GAZEBO_RESOURCE_PATH`. So it might be more consistent if we call it `IGN_GUI_RESOURCE_PATH`.
From the description of the original issue, maybe we only want `IGN_GUI_CONFIG_PATH` and not the `*RESOURCE*` variable?~~

~~- Is there a way to test at the `ign gui` level that automatically close the GUI?
Currently, the added unit test brings up the GUI via `popen`, but doesn't close it. That's not going to work as an automated test, as it requires manual closing of the window. The way ign-gazebo does it is by running headless (`-s`), which ign-gui doesn't have a flag for. Other ign-gui tests that automatically close the window initialize `Application` or `MainWindow` in the code. Here, we are testing the Ruby code at the `ign` command a level above, so we don't have those objects.
Should we just not test the valid cases? Only the valid cases bring up the GUI. The invalid cases just print a message and exit.~~

## Test it

### Environment variable should show up in help message:
```
$ ign gui --help
...
Environment variables:                                                  
  GZ_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI     
 resources such as configuration files.
```

### Unit test:
```
./build/ignition-gui3/bin/UNIT_Application_TEST 
```

### Manual test:

Test with config files in `examples/config/`.
For all following commands, replace environment variable with path on your machine.

Valid environment variable and file, should show color themed GUI:
```
GZ_GUI_RESOURCE_PATH=/path/to/ign/src/ign-gui/examples/config ign gui --config style.config
```

Invalid file:
```
# No env var
ign gui --config pubsub.config
[GUI] [Err] [Application.cc:263] Failed to load file [style.config]: XMLError

# Valid env var, invalid file
$ GZ_GUI_RESOURCE_PATH=/path/to/ign/src/ign-gui/examples/config ign gui --config pubsub.config2
[GUI] [Err] [Application.cc:263] Failed to load file [style.config]: XMLError
```

Multiple paths, some valid, some invalid. Should find file and load up correct GUI:
```
GZ_GUI_RESOURCE_PATH=/invalid:/path/to/ign/src/ign-gui/examples/config ign gui --config style.config
```

### Test at ign-gazebo level:

Should show color themed GUI (add Gz Scene 3D plugin to see the world axis):
```
GZ_GUI_RESOURCE_PATH=/path/to/ign/src/ign-gui/examples/config ign gazebo --gui-config style.config default.sdf
```

## Do after merging

New env var should be added to the `ign gazebo` help message after this is merged.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
