### PR TITLE
Sort plugin list in alphabetical order (including when filtering)

### DIFF
--- a/include/ignition/gui/qml/PluginMenu.qml
+++ b/include/ignition/gui/qml/PluginMenu.qml
@@ -95,6 +95,12 @@ Popup {
   IgnSortFilterModel {
     id: filteredModel
 
+    lessThan: function(left, right) {
+      var leftStr = left.modelData.toLowerCase();
+      var rightStr = right.modelData.toLowerCase();
+      return leftStr < rightStr;
+    }
+
     filterAcceptsItem: function(item) {
       var itemStr = item.modelData.toLowerCase();
       var filterStr = searchField.text.toLowerCase();


### PR DESCRIPTION
Signed-off-by: Mabel Zhang <mabel@openrobotics.org>

# 🎉 New feature

Closes https://github.com/ignitionrobotics/ign-gazebo/issues/175
Follows up on #277

## Summary
Sort plugin menu in alphabetical order by overriding `lessThan`, the default defined in `include/ignition/gui/qml/IgnSortFilterModel.qml`.

## Test it

```
ign gui
```
Click on the three vertical dots in the upper-right corner for the plugin menu.

Before (not sorted):
![2022-04-13-204024_1200x1000_scrot_unsorted](https://user-images.githubusercontent.com/7608908/163292141-10814c64-9397-4f4a-a6f7-ae62df231dff.png)

After (sorted alphabetically):
![2022-04-13-203943_1200x1000_scrot_sorted](https://user-images.githubusercontent.com/7608908/163292124-9f99fbe7-dc04-42d4-8a72-ffb58f437da0.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.