### PR TITLE
Fix Qt6 migration tutorial link in migration guide

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -10,7 +10,7 @@ release will remove the deprecated code.
 * Upgraded GUI framework from Qt5 to Qt6. All GUI plugins distributed by gz-gui
 have been migrated. This upgrade affects all users' custom Gazebo GUI plugins.
 Please see the
-[Qt6 Migration tutorial](https://github.com/gazebosim/gz-gui/blob/main/tutorials/09_migration_qt6.html)
+[Qt6 Migration tutorial](https://github.com/gazebosim/gz-gui/blob/main/tutorials/09_migration_qt6.md)
 for information on how to port your Qt5 based plugins to Qt6.
 
 * The environment variable `GZ_GUI_PLUGIN_INSTALL_DIR` is removed. Use


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Fixes incorrect link in migration guide

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

