### PR TITLE
Update changelog for Jetty

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -47,9 +47,6 @@
 1. Fix Transport Plotting GUI plugin
     * [Pull request #667](https://github.com/gazebosim/gz-gui/pull/667)
 
-1. Fix Transport Plotting GUI plugin
-    * [Pull request #667](https://github.com/gazebosim/gz-gui/pull/667)
-
 1. Fix GridConfig pose updates
     * [Pull request #658](https://github.com/gazebosim/gz-gui/pull/658)
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/18

## Summary
Update changelog for gz-gui 10.0.0.

Compare to https://github.com/gazebosim/gz-gui/compare/gz-gui9_9.0.1...main

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.