### PR TITLE
Replace Protobuf DebugString with PrintToString

### DIFF
--- a/src/plugins/publisher/Publisher.cc
+++ b/src/plugins/publisher/Publisher.cc
@@ -15,14 +15,16 @@
  *
 */
 
-#include <gz/utils/ImplPtr.hh>
-#include <iostream>
+#include "Publisher.hh"
+
+#include <google/protobuf/text_format.h>
+
 #include <gz/common/Console.hh>
 #include <gz/msgs/Utility.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
-
-#include "Publisher.hh"
+#include <gz/utils/ImplPtr.hh>
+#include <string>
 
 namespace gz::gui::plugins
 {
@@ -107,7 +109,14 @@ void Publisher::OnPublish(const bool _checked)
 
   // Check it's possible to create message
   auto msg = msgs::Factory::New(msgType, msgData);
-  if (!msg || (msg->DebugString().empty() && !msgData.empty()))
+
+  std::string msgToText;
+  using google::protobuf::TextFormat;
+  if (msg)
+  {
+    TextFormat::PrintToString(*msg, &msgToText);
+  }
+  if (!msg || (msgToText.empty() && !msgData.empty()))
   {
     gzerr << "Unable to create message of type[" << msgType << "] "
       << "with data[" << msgData << "].\n";

--- a/src/plugins/topic_echo/TopicEcho.cc
+++ b/src/plugins/topic_echo/TopicEcho.cc
@@ -15,14 +15,18 @@
  *
 */
 
-#include <gz/utils/ImplPtr.hh>
-#include <iostream>
+#include "TopicEcho.hh"
+
+#include <google/protobuf/text_format.h>
+
 #include <gz/common/Console.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
+#include <gz/utils/ImplPtr.hh>
+#include <iostream>
+#include <string>
 
 #include "gz/gui/Application.hh"
-#include "TopicEcho.hh"
 
 namespace gz::gui::plugins
 {
@@ -109,8 +113,14 @@ void TopicEcho::OnMessage(const google::protobuf::Message &_msg)
     return;
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-
-  emit this->AddMsg(QString::fromStdString(_msg.DebugString()));
+  if (std::string str; google::protobuf::TextFormat::PrintToString(_msg, &str))
+  {
+    emit this->AddMsg(QString::fromStdString(str));
+  }
+  else
+  {
+    gzerr << "Error printing message" << std::endl;
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
As of Protobuf 30, DebugString may contain some randomized content in order to redact sensitive information. This adapts https://github.com/gazebosim/gz-transport/pull/685/ for gz-gui.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.