### PR TITLE
Configurable anti-aliasing for MinimalScene

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -791,7 +791,7 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   this->dataPtr->camera->SetImageHeight(this->textureSize.height());
   this->dataPtr->camera->SetImageFormat(this->dataPtr->camera->ImageFormat(),
                                         true);
-  this->dataPtr->camera->SetAntiAliasing(8);
+  this->dataPtr->camera->SetAntiAliasing(this->cameraAntiAliasing);
   this->dataPtr->camera->SetHFOV(this->cameraHFOV);
   // setting the size and calling PreRender should cause the render texture to
   // be rebuilt
@@ -1335,6 +1335,12 @@ void RenderWindowItem::SetCameraFarClip(double _far)
 }
 
 /////////////////////////////////////////////////
+void RenderWindowItem::SetAntiAliasing(unsigned int _aa)
+{
+  this->dataPtr->renderThread->gzRenderer.cameraAntiAliasing = _aa;
+}
+
+/////////////////////////////////////////////////
 void RenderWindowItem::SetSkyEnabled(const bool &_sky)
 {
   this->dataPtr->renderThread->gzRenderer.skyEnable = _sky;
@@ -1485,6 +1491,24 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         {
           renderWindow->SetCameraFarClip(f);
         }
+      }
+    }
+
+    elem = _pluginElem->FirstChildElement("anti_aliasing");
+    if (nullptr != elem && nullptr != elem->GetText())
+    {
+      unsigned int aa{};
+      std::stringstream aaStr(std::string(elem->GetText()));
+      aaStr >> aa;
+      if (aaStr.fail())
+      {
+        gzerr << "Unable to set anti-aliasing <anti_aliasing> to '"
+              << elem->GetText()
+              << "' using default value" << std::endl;
+      }
+      else
+      {
+        renderWindow->SetAntiAliasing(aa);
       }
     }
 

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -64,6 +64,7 @@ namespace gz::gui::plugins
   /// * \<sky\> : If present, sky is enabled.
   /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees,
   ///                        defaults to 90
+  /// * \<anti_aliasing> : Optional level of anti-aliasing, default is 8
   /// * \<graphics_api\> : Optional graphics API name. Valid choices are:
   ///                      'opengl', 'metal'. Defaults to 'opengl'.
   /// * \<view_controller> : Set the view controller (InteractiveViewControl
@@ -222,6 +223,9 @@ namespace gz::gui::plugins
     /// \brief Default camera far clipping plane distance
     public: double cameraFarClip = 1000.0;
 
+    /// \brief Default camera anit-aliasing level
+    public: unsigned int cameraAntiAliasing = 8;
+
     /// \brief Scene background color
     public: math::Color backgroundColor = math::Color::Black;
 
@@ -357,6 +361,10 @@ namespace gz::gui::plugins
     /// \brief Set the render window camera's far clipping plane distance
     /// \param[in] _far Far clipping plane distance
     public: void SetCameraFarClip(double _far);
+
+    /// \brief Set the render window camera's anti-aliasing level
+    /// \param[in] _aa Anti-aliasing level
+    public: void SetAntiAliasing(unsigned int _aa);
 
     /// \brief Called when the mouse hovers to a new position.
     /// \param[in] _hoverPos 2D coordinates of the hovered mouse position on


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Making anti-aliasing configurable can allow user to control their performance-quality ratio for GUI. AA can be quite expensive.
Same option is available for sensor [camera](https://sdformat.org/spec/1.12/sensor/#image_anti_aliasing)
Also different backends can have different set of allowed AA levels, for Ogre2 it's quite common to see message:
`[warning] [Ogre2RenderTarget.cc:668] [GUI] Anti-aliasing level of '8' is not supported; valid FSAA levels are: [ 0 4 ].`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.