### PR TITLE
Suppress deprecation warnings for invalidateFilter

### DIFF
--- a/src/SearchModel.cc
+++ b/src/SearchModel.cc
@@ -148,14 +148,12 @@ void SearchModel::SetSearch(const QString &_search)
 {
   this->search = _search;
 
-  // Trigger repaint on whole model
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
   // invalidateFilter is deprecated in qt 6.10
   // https://github.com/gazebosim/gz-gui/issues/729
   GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  // Trigger repaint on whole model
   this->invalidateFilter();
   GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-#endif
 
   // TODO(anyone): Figure out why filterChanged works for TopicViewer but not
   // TopicsStats


### PR DESCRIPTION
# 🦟 Bug fix

Mitigation for #729 

## Summary

Added suppression of deprecation warnings for invalidateFilter in Qt 6.10.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
