### PR TITLE
Prepare for 6.9.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui6 VERSION 6.8.0)
+project(ignition-gui6 VERSION 6.9.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,38 @@
 ## Gazebo GUI 6
 
-### Gazebo GUI 6.7.0 (2023-05-12)
+### Gazebo GUI 6.9.0 (2026-02-12)
+
+1. Configurable anti-aliasing for MinimalScene
+    * [Pull request #723](https://github.com/gazebosim/gz-gui/pull/723)
+
+1. Fortress: disable Ubuntu Focal CI
+    * [Pull request #732](https://github.com/gazebosim/gz-gui/pull/732)
+
+1. Suppress new Jammy warnings
+    * [Pull request #404](https://github.com/gazebosim/gz-gui/pull/404)
+
+1. Fix link in scene tutorial
+    * [Pull request #714](https://github.com/gazebosim/gz-gui/pull/714)
+
+1. Replace Protobuf DebugString with PrintToString
+    * [Pull request #703](https://github.com/gazebosim/gz-gui/pull/703)
+
+1. Fix compatibility with protobuf v30 (cpp 6.30.0)
+    * [Pull request #677](https://github.com/gazebosim/gz-gui/pull/677)
+
+1. Support `<gz-gui>` tag in plugin config
+    * [Pull request #607](https://github.com/gazebosim/gz-gui/pull/607)
+
+1. Update github action workflows
+    * [Pull request #597](https://github.com/gazebosim/gz-gui/pull/597)
+
+1. Update github issue template
+    * [Pull request #591](https://github.com/gazebosim/gz-gui/pull/591)
+
+1. Find any major version of Protobuf
+    * [Pull request #544](https://github.com/gazebosim/gz-gui/pull/544)
+
+### Gazebo GUI 6.8.0 (2023-05-12)
 
 1. Add degree as an optional unit for rotation in GzPose.
     * [Pull request #475](https://github.com/gazebosim/gz-gui/pull/475)


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.9.0 release.

Comparison to 6.8.0: https://github.com/gazebosim/gz-gui/compare/ignition-gui6_6.8.0...ign-gui6

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.