### PR TITLE
Remove build RUNPATH from installed libGrid3D.so (backport #676)

### DIFF
--- a/src/plugins/grid_config/CMakeLists.txt
+++ b/src/plugins/grid_config/CMakeLists.txt
@@ -7,8 +7,14 @@ gz_gui_add_plugin(GridConfig
     gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
 )
 
-# Also install as Grid3D, which was a legacy plugin with a subset of features
-install (
-  FILES $<TARGET_FILE:GridConfig>
-  RENAME ${CMAKE_SHARED_LIBRARY_PREFIX}Grid3D${CMAKE_SHARED_LIBRARY_SUFFIX}
-  DESTINATION ${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR})
+# Also install Grid3D (a legacy plugin with a subset of features) by copying the installed GridConfig library. This ensures the correct RUNPATH is used.
+
+install(CODE "
+  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\"
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGrid3D.so\")
+  else()
+    message(WARNING \"Source file for Grid3D (legacy plugin) copy not found, skipping copy: \${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+  endif()
+")

--- a/src/plugins/grid_config/CMakeLists.txt
+++ b/src/plugins/grid_config/CMakeLists.txt
@@ -10,11 +10,11 @@ gz_gui_add_plugin(GridConfig
 # Also install Grid3D (a legacy plugin with a subset of features) by copying the installed GridConfig library. This ensures the correct RUNPATH is used.
 
 install(CODE "
-  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig${CMAKE_SHARED_LIBRARY_SUFFIX}\")
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\"
-    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGrid3D.so\")
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig${CMAKE_SHARED_LIBRARY_SUFFIX}\"
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGrid3D${CMAKE_SHARED_LIBRARY_SUFFIX}\")
   else()
-    message(WARNING \"Source file for Grid3D (legacy plugin) copy not found, skipping copy: \${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+    message(WARNING \"Source file for Grid3D (legacy plugin) copy not found, skipping copy: \${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig${CMAKE_SHARED_LIBRARY_SUFFIX}\")
   endif()
 ")


### PR DESCRIPTION
Hi,

This backport #676 to gz-gui8

--- 

Installs libGrid3D.so (a legacy alias for libGridConfig.so) by copying the already installed libGridConfig.so using install(CODE ...) instead of install(FILES ...). This ensures the build directory RUNPATH is correctly stripped, matching other installed plugins.

Fixes #627