### PR TITLE
Publisher: check result of PrintToString

### DIFF
--- a/src/plugins/publisher/Publisher.cc
+++ b/src/plugins/publisher/Publisher.cc
@@ -110,13 +110,14 @@ void Publisher::OnPublish(const bool _checked)
   // Check it's possible to create message
   auto msg = msgs::Factory::New(msgType, msgData);
 
+  bool msgToTextResult = true;
   std::string msgToText;
   using google::protobuf::TextFormat;
   if (msg)
   {
-    TextFormat::PrintToString(*msg, &msgToText);
+    msgToTextResult = TextFormat::PrintToString(*msg, &msgToText);
   }
-  if (!msg || (msgToText.empty() && !msgData.empty()))
+  if (!msg || !msgToTextResult || (msgToText.empty() && !msgData.empty()))
   {
     gzerr << "Unable to create message of type[" << msgType << "] "
       << "with data[" << msgData << "].\n";


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compiler warning (similar to https://github.com/gazebosim/gz-transport/issues/810)

## Summary

Protobuf 34.0 added `[[nodiscard]]` to several APIs, causing `unused-result` warnings on homebrew (which now has Protobuf 34.0. This fixes the one warning in gz-gui by checking the return value of `PrintToString`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
