### PR TITLE
Reintroduce pointcloud render without Float_V message

### DIFF
--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -482,10 +482,11 @@ void PointCloud::Implementation::PublishMarkers()
 
     if (r_detected.empty() || g_detected.empty() || b_detected.empty()) 
     {
+      gzerr << "Using default color" << std::endl;
       // Color fields unavailable just set the color based on our max color
       for (std::size_t i = 0;  i < num_points; ++iterX, ++iterY, ++iterZ, ++i)
       {
-        gz::msgs::Set(marker.add_materials()->mutable_diffuse(), maxC);
+        gz::msgs::Set(marker.add_materials()->mutable_diffuse(), minC);
         gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
           *iterX,
           *iterY,

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -21,6 +21,8 @@
 #include "gz/msgs/pointcloud_packed.pb.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <gz/msgs/details/pointcloud_packed.pb.h>
 #include <gz/utils/ImplPtr.hh>
 #include <limits>
 #include <string>
@@ -96,6 +98,11 @@ class PointCloud::Implementation
 
   /// \brief True if showing, changeable at runtime
   public: bool showing{true};
+  
+  /// Sometimes we may just want to have a pointcloud
+  /// Without a float field. This is triggered when we
+  /// set a scalar float topic to subscribe to.
+  public: bool hasFloatTopic{false};
 };
 
 /////////////////////////////////////////////////
@@ -182,6 +189,7 @@ void PointCloud::OnPointCloudTopic(const QString &_pointCloudTopic)
 void PointCloud::OnFloatVTopic(const QString &_floatVTopic)
 {
   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
+  
   // Unsubscribe from previous choice
   if (!this->dataPtr->floatVTopic.empty() &&
       !this->dataPtr->node.Unsubscribe(this->dataPtr->floatVTopic))
@@ -208,6 +216,7 @@ void PointCloud::OnFloatVTopic(const QString &_floatVTopic)
     return;
   }
   gzmsg << "Subscribed to " << this->dataPtr->floatVTopic << std::endl;
+  this->dataPtr->hasFloatTopic = true;
 }
 
 //////////////////////////////////////////////////
@@ -411,30 +420,99 @@ void PointCloud::Implementation::PublishMarkers()
     gzwarn << "Mal-formatted pointcloud" << std::endl;
   }
 
-  for (; ptIdx < std::min<int>(this->floatVMsg.data().size(), num_points);
-    ++iterX, ++iterY, ++iterZ, ++ptIdx)
-  {
-    // Value from float vector, if available. Otherwise publish all data as
-    // zeroes.
-    float dataVal = this->floatVMsg.data(ptIdx);
+  if (this->hasFloatTopic) {
+    for (; ptIdx < std::min<int>(this->floatVMsg.data().size(), num_points);
+      ++iterX, ++iterY, ++iterZ, ++ptIdx)
+    {
+      // Value from float vector, if available. Otherwise publish all data as
+      // zeroes.
+      float dataVal = this->floatVMsg.data(ptIdx);
 
-    // Don't visualize NaN
-    if (std::isnan(dataVal))
-      continue;
+      // Don't visualize NaN
+      if (std::isnan(dataVal))
+        continue;
 
-    auto ratio = floatRange > 0 ?
-        (dataVal - this->minFloatV) / floatRange : 0.0f;
-    gz:: math::Color color{
-      minC.R() + (maxC.R() - minC.R()) * ratio,
-      minC.G() + (maxC.G() - minC.G()) * ratio,
-      minC.B() + (maxC.B() - minC.B()) * ratio
-    };
+      auto ratio = floatRange > 0 ?
+          (dataVal - this->minFloatV) / floatRange : 0.0f;
+      gz:: math::Color color{
+        minC.R() + (maxC.R() - minC.R()) * ratio,
+        minC.G() + (maxC.G() - minC.G()) * ratio,
+        minC.B() + (maxC.B() - minC.B()) * ratio
+      };
 
-    gz::msgs::Set(marker.add_materials()->mutable_diffuse(), color);
-    gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
-      *iterX,
-      *iterY,
-      *iterZ));
+      gz::msgs::Set(marker.add_materials()->mutable_diffuse(), color);
+      gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
+        *iterX,
+        *iterY,
+        *iterZ));
+    }
+  }
+  else {
+    // Falback to coloring using the point cloud (if possible)
+    // Else fall back to a default color
+    std::string r_detected = "", g_detected = "", b_detected = "";
+    for(auto field : this->pointCloudMsg.field()){
+      if(field.name() == "r" || field.name() == "red") {
+        if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
+        {
+          gzwarn << "Only 256 bit color supported" << std::endl;
+          continue;
+        }
+        r_detected = field.name();
+      }
+
+      if(field.name() == "g" || field.name() == "green") {
+        if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
+        {
+          gzwarn << "Only 256 bit color supported" << std::endl;
+          continue;
+        }
+        g_detected = field.name();
+      }
+
+      if(field.name() == "b" || field.name() == "blue") {
+        if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
+        {
+          gzwarn << "Only 256 bit color supported" << std::endl;
+          continue;
+        }        
+        b_detected = field.name();
+      }   
+    }
+
+    if (r_detected.empty() || g_detected.empty() || b_detected.empty()) 
+    {
+      // Color fields unavailable just set the color based on our max color
+      for (std::size_t i = 0;  i < num_points; ++iterX, ++iterY, ++iterZ, ++i)
+      {
+        gz::msgs::Set(marker.add_materials()->mutable_diffuse(), maxC);
+        gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
+          *iterX,
+          *iterY,
+          *iterZ));      
+      } 
+    }
+    else
+    {
+          
+      gz::msgs::PointCloudPackedIterator<uint8_t>
+        iterR(this->pointCloudMsg, r_detected);
+      gz::msgs::PointCloudPackedIterator<uint8_t>
+        iterG(this->pointCloudMsg, g_detected);
+      gz::msgs::PointCloudPackedIterator<uint8_t>
+        iterB(this->pointCloudMsg, b_detected);
+      
+      for (std::size_t i = 0;  i < num_points; ++iterX, ++iterY, ++iterZ, ++i, ++iterR, ++iterG, ++iterB)
+      {
+        gz::msgs::Set(marker.add_materials()->mutable_diffuse(), math::Color(
+                        ((float)*iterR)/255.0, ((float)*iterG)/255.0 , ((float)*iterB)/255.0
+                      ));
+        gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
+          *iterX,
+          *iterY,
+          *iterZ));      
+      }  
+    }
   }
 
   this->node.Request("/marker", marker);

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -496,7 +496,7 @@ void PointCloud::Implementation::PublishMarkers()
       }
     }
     else
-    {    
+    {
       gz::msgs::PointCloudPackedIterator<uint8_t>
         iterR(this->pointCloudMsg, r_detected);
       gz::msgs::PointCloudPackedIterator<uint8_t>
@@ -507,15 +507,15 @@ void PointCloud::Implementation::PublishMarkers()
         ++iterX, ++iterY, ++iterZ, ++i, ++iterR, ++iterG, ++iterB)
       {
         gz::msgs::Set(marker.add_materials()->mutable_diffuse(), math::Color(
-                        ((float)*iterR)/255.0,
-                        ((float)*iterG)/255.0,
-                        ((float)*iterB)/255.0
+                        static_cast<float>(*iterR)/255.0,
+                        static_cast<float>(*iterG)/255.0,
+                        static_cast<float>(*iterB)/255.0
                       ));
         gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
           *iterX,
           *iterY,
-          *iterZ));      
-      }  
+          *iterZ));
+      }
     }
   }
 

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -448,7 +448,7 @@ void PointCloud::Implementation::PublishMarkers()
     }
   }
   else {
-    // Falback to coloring using the point cloud (if possible)
+    // Fall back to coloring using the point cloud (if possible)
     // Else fall back to a default color
     std::string r_detected = "", g_detected = "", b_detected = "";
     for(auto field : this->pointCloudMsg.field()){

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -453,7 +453,8 @@ void PointCloud::Implementation::PublishMarkers()
     // Fall back to coloring using the point cloud (if possible)
     // Else fall back to a default color
     std::string r_detected = "", g_detected = "", b_detected = "";
-    for(auto field : this->pointCloudMsg.field()){
+    for (auto field : this->pointCloudMsg.field())
+    {
       if(field.name() == "r" || field.name() == "red") {
         if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
         {

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -98,7 +98,7 @@ class PointCloud::Implementation
 
   /// \brief True if showing, changeable at runtime
   public: bool showing{true};
-  
+
   /// Sometimes we may just want to have a pointcloud
   /// Without a float field. This is triggered when we
   /// set a scalar float topic to subscribe to.
@@ -189,7 +189,7 @@ void PointCloud::OnPointCloudTopic(const QString &_pointCloudTopic)
 void PointCloud::OnFloatVTopic(const QString &_floatVTopic)
 {
   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
-  
+
   // Unsubscribe from previous choice
   if (!this->dataPtr->floatVTopic.empty() &&
       !this->dataPtr->node.Unsubscribe(this->dataPtr->floatVTopic))
@@ -420,7 +420,8 @@ void PointCloud::Implementation::PublishMarkers()
     gzwarn << "Mal-formatted pointcloud" << std::endl;
   }
 
-  if (this->hasFloatTopic) {
+  if (this->hasFloatTopic)
+  {
     for (; ptIdx < std::min<int>(this->floatVMsg.data().size(), num_points);
       ++iterX, ++iterY, ++iterZ, ++ptIdx)
     {
@@ -447,7 +448,8 @@ void PointCloud::Implementation::PublishMarkers()
         *iterZ));
     }
   }
-  else {
+  else
+  {
     // Fall back to coloring using the point cloud (if possible)
     // Else fall back to a default color
     std::string r_detected = "", g_detected = "", b_detected = "";
@@ -475,12 +477,12 @@ void PointCloud::Implementation::PublishMarkers()
         {
           gzwarn << "Only 256 bit color supported" << std::endl;
           continue;
-        }        
+        }
         b_detected = field.name();
-      }   
+      }
     }
 
-    if (r_detected.empty() || g_detected.empty() || b_detected.empty()) 
+    if (r_detected.empty() || g_detected.empty() || b_detected.empty())
     {
       gzerr << "Using default color" << std::endl;
       // Color fields unavailable just set the color based on our max color
@@ -490,23 +492,24 @@ void PointCloud::Implementation::PublishMarkers()
         gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
           *iterX,
           *iterY,
-          *iterZ));      
-      } 
+          *iterZ));
+      }
     }
     else
-    {
-          
+    {    
       gz::msgs::PointCloudPackedIterator<uint8_t>
         iterR(this->pointCloudMsg, r_detected);
       gz::msgs::PointCloudPackedIterator<uint8_t>
         iterG(this->pointCloudMsg, g_detected);
       gz::msgs::PointCloudPackedIterator<uint8_t>
         iterB(this->pointCloudMsg, b_detected);
-      
-      for (std::size_t i = 0;  i < num_points; ++iterX, ++iterY, ++iterZ, ++i, ++iterR, ++iterG, ++iterB)
+      for (std::size_t i = 0;  i < num_points;
+        ++iterX, ++iterY, ++iterZ, ++i, ++iterR, ++iterG, ++iterB)
       {
         gz::msgs::Set(marker.add_materials()->mutable_diffuse(), math::Color(
-                        ((float)*iterR)/255.0, ((float)*iterG)/255.0 , ((float)*iterB)/255.0
+                        ((float)*iterR)/255.0,
+                        ((float)*iterG)/255.0,
+                        ((float)*iterB)/255.0
                       ));
         gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
           *iterX,

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -99,7 +99,7 @@ class PointCloud::Implementation
   /// \brief True if showing, changeable at runtime
   public: bool showing{true};
 
-  /// Sometimes we may just want to have a pointcloud
+  /// \brief Sometimes we may just want to have a pointcloud
   /// Without a float field. This is triggered when we
   /// set a scalar float topic to subscribe to.
   public: bool hasFloatTopic{false};
@@ -452,10 +452,11 @@ void PointCloud::Implementation::PublishMarkers()
   {
     // Fall back to coloring using the point cloud (if possible)
     // Else fall back to a default color
-    std::string r_detected = "", g_detected = "", b_detected = "";
+    std::string r_detected, g_detected, b_detected;
     for (auto field : this->pointCloudMsg.field())
     {
-      if(field.name() == "r" || field.name() == "red") {
+      if (field.name() == "r" || field.name() == "red")
+      {
         if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
         {
           gzwarn << "Only 256 bit color supported" << std::endl;
@@ -464,7 +465,8 @@ void PointCloud::Implementation::PublishMarkers()
         r_detected = field.name();
       }
 
-      if(field.name() == "g" || field.name() == "green") {
+      if (field.name() == "g" || field.name() == "green")
+      {
         if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
         {
           gzwarn << "Only 256 bit color supported" << std::endl;
@@ -473,7 +475,8 @@ void PointCloud::Implementation::PublishMarkers()
         g_detected = field.name();
       }
 
-      if(field.name() == "b" || field.name() == "blue") {
+      if (field.name() == "b" || field.name() == "blue")
+      {
         if (field.datatype() != msgs::PointCloudPacked::Field::UINT8)
         {
           gzwarn << "Only 256 bit color supported" << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

[This bug](https://github.com/gazebosim/gz-gui/pull/494#issuecomment-3995382967)

## Summary
Re-introduce point cloud rendering without the Float_V message.

<img width="1198" height="996" alt="Screenshot From 2026-03-17 11-49-46" src="https://github.com/user-attachments/assets/fe538b5b-d93a-429b-9900-3b13345dece1" />


I tested it with the following program:
```C++
#include <iostream>
#include <cmath>
#include <thread>
#include <chrono>
#include <gz/msgs/pointcloud_packed.pb.h>
#include <gz/msgs/PointCloudPackedUtils.hh>
#include <gz/transport/Node.hh>

int main(int argc, char** argv)
{
  // Create a transport node.
  gz::transport::Node node;

  // Define the topic to publish on.
  std::string topic = "/sphere_points";

  // Create a publisher for PointCloudPacked messages.
  auto pub = node.Advertise<gz::msgs::PointCloudPacked>(topic);

  if (!pub)
  {
    std::cerr << "Error advertising topic [" << topic << "]" << std::endl;
    return -1;
  }

  // Sphere parameters
  double radius = 1.0;
  int num_theta = 20;
  int num_phi = 40;

  // Prepare the message
  gz::msgs::PointCloudPacked msg;
  // Initialize header
  msg.mutable_header()->mutable_stamp()->set_sec(0);
  msg.mutable_header()->mutable_stamp()->set_nsec(0);

  // Initialize PointCloudPacked
  gz::msgs::InitPointCloudPacked(msg, "frame_id", false,
      {{"xyz", gz::msgs::PointCloudPacked::Field::FLOAT32}});

  int num_points = (num_theta + 1) * num_phi;
  msg.set_width(num_points);
  msg.set_height(1);
  msg.set_is_dense(true);
  msg.mutable_data()->resize(num_points * msg.point_step());

  gz::msgs::PointCloudPackedIterator<float> iterX(msg, "x");
  gz::msgs::PointCloudPackedIterator<float> iterY(msg, "y");
  gz::msgs::PointCloudPackedIterator<float> iterZ(msg, "z");

  const double PI = std::acos(-1.0);

  for (int i = 0; i <= num_theta; ++i)
  {
    double theta = PI * i / num_theta;
    for (int j = 0; j < num_phi; ++j)
    {
      double phi = 2.0 * PI * j / num_phi;

      double x = radius * std::sin(theta) * std::cos(phi);
      double y = radius * std::sin(theta) * std::sin(phi);
      double z = radius * std::cos(theta);

      *iterX = static_cast<float>(x);
      *iterY = static_cast<float>(y);
      *iterZ = static_cast<float>(z);
      ++iterX;
      ++iterY;
      ++iterZ;
    }
  }

  std::cout << "Publishing a sphere with " << num_points
            << " points on topic [" << topic << "]" << std::endl;

  // Publish the message in a loop
  while (true)
  {
    if (!pub.Publish(msg))
    {
        std::cerr << "Failed to publish message" << std::endl;
    }
    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
  }

  return 0;
}

```

TODO: Color support: I think we should not implement the color rendering support here, rather perhaps we should have some PointCloud representation in `gz-math`. For now there is rudimentary support for colors in this PR. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)



**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

