### PR TITLE
Fix TopicEcho_TEST race condition with Publisher_TEST

### DIFF
--- a/src/plugins/topic_echo/TopicEcho_TEST.cc
+++ b/src/plugins/topic_echo/TopicEcho_TEST.cc
@@ -118,11 +118,14 @@ TEST(TopicEchoTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Echo))
   EXPECT_FALSE(plugin->Paused());
 
   // Start echoing
+  // Use a unique topic to avoid collisions with Publisher_TEST (whose default
+  // topic is also "/echo") when tests run in parallel.
+  plugin->SetTopic("/test_topic_echo");
   plugin->OnEcho(true);
 
   // Publish string
   transport::Node node;
-  auto pub = node.Advertise<msgs::StringMsg>("/echo");
+  auto pub = node.Advertise<msgs::StringMsg>("/test_topic_echo");
   msgs::StringMsg msg;
   msg.set_data("example string");
   pub.Publish(msg);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Both `TopicEcho_TEST` and `Publisher_TEST` use the `/echo` topic. When ctest runs tests in parallel (e.g. `ctest -j$(nproc)`), messages from one test leak into the other, causing non-deterministic failures.

This PR uses a unique topic name (`/test_topic_echo`) in `TopicEcho_TEST` by calling `SetTopic()` before `OnEcho(true)`. The Publisher plugin's default topic is `/echo` (which `Publisher_TEST` validates), so `TopicEcho_TEST` is the right one to change.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.