### PR TITLE
Cherry-pick Forward port from gz-gui10

### DIFF
--- a/include/gz/gui/qml/Main.qml
+++ b/include/gz/gui/qml/Main.qml
@@ -300,7 +300,7 @@ ApplicationWindow
     currentFolder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
     nameFilters: [ "Config files (*.config)" ]
     onAccepted: {
-      _MainWindow.OnLoadConfig(fileUrl)
+      _MainWindow.OnLoadConfig(selectedFile)
     }
   }
 
@@ -314,7 +314,7 @@ ApplicationWindow
     currentFolder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
     nameFilters: [ "Config files (*.config)" ]
     onAccepted: {
-      var selected = fileUrl.toString();
+      var selected = selectedFile.toString();
 
       if (!selected.endsWith(".config"))
       {

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <build_depend>gz-cmake3</build_depend>
+  <build_depend>gz-cmake</build_depend>
 
   <depend>gz-common</depend>
   <depend>gz-math</depend>

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -168,6 +168,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
   }
   else
   {
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
     gzdbg << "Qt using OpenGL graphics interface" << std::endl;
   }
 #endif

--- a/tutorials/02_commandline.md
+++ b/tutorials/02_commandline.md
@@ -32,6 +32,12 @@ If you have Gazebo Tools installed, you can use the `gz gui` command line tool:
       --force-version <VERSION>  Use a specific library version.
 
       --versions                 Show the available versions.
+      
+    Environment variables:
+      GZ_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI
+     resources such as configuration files.
+
+
 
 When using the command line tool, all console messages are logged to
 `$HOME/.gz/gui/log/<timestamp>`.

--- a/tutorials/07_config.md
+++ b/tutorials/07_config.md
@@ -30,7 +30,7 @@ environment variable `GZ_GUI_RESOURCE_PATH`, like so:
 `GZ_GUI_RESOURCE_PATH=/absolute/path/to/ gz gui --config example.config`
 
 From the C++ API, pass the file path to
-[Application::LoadConfig](https://gazebosim.org/api/gui/6.0/classignition_1_1gui_1_1Application.html#a03c4c3a1b1e58cc4bff05658f21fff17).
+[Application::LoadConfig](https://gazebosim.org/api/gui/10/classgz_1_1gui_1_1Application.html#a9bcca11f0018a1fb97007f7817a10b75).
 
 ### File structure
 
@@ -45,7 +45,7 @@ Gazebo GUI accepts the following top-level elements on a config file:
       [plugin_params.config](https://github.com/gazebosim/gz-gui/blob/main/examples/config/plugin_params.config)
       for an example.
     * custom elements: Developers can read custom plugin configurations overriding the
-      [Plugin::LoadConfig](https://gazebosim.org/api/gui/6.0/classignition_1_1gui_1_1Plugin.html#a720646.0af4cd247b994b905559fd4ee)
+      [Plugin::LoadConfig](https://gazebosim.org/api/gui/10/classgz_1_1gui_1_1Plugin.html#a23b77569f666353a9794d926b949a179)
       function, see the
       [HelloPlugin](https://github.com/gazebosim/gz-gui/blob/main/examples/plugin/hello_plugin/HelloPlugin.cc)
       example.

--- a/tutorials/scene.md
+++ b/tutorials/scene.md
@@ -17,7 +17,7 @@ adding, modifying and removing rendering elements from the scene must be
 performed by other plugins that work alongside the minimal scene.
 
 Each application will have a different way of updating the 3D scene. For example,
-[Gazebo](https://gazebosim.org/libs/gazebo) updates the scene
+[Gazebo](https://gazebosim.org/libs/sim) updates the scene
 based on its entities and components, and
 [Gazebo RViz](https://github.com/gazebosim/gz-rviz/)
 updates the scene based on ROS 2 messages. Each of these applications provides


### PR DESCRIPTION
# ➡️ Forward port

Port gz-gui10 to main:

Ran `git cherry HEAD origin/gz-gui10  -v | grep + | v` and manually filtered relevant changes:

+ 04bfafa22fcc1b77b00bbc327fdb10c6f7c84e27 Update 02_commandline.md with help message (#708)
+ f9fd440e22ca2aec6d30eb5435712b27aec287df Fix dead links in config tutorial (#709)
+ 8c306f6bea4f96977f47ca9bc4065cf7056ab5eb Fix loading and saving config (#711)
+ 6a2c59c440ced720ec937ed5514f719024faceab Explicitly set OpenGL as the graphics API for QtQuick (#712)
+ 5d32af704a164028f50bf6c0c8cd47e9e0cd53d3 Update dependency on gz-cmake3 to gz-cmake (#713)
+ 0532579627025b3e90963a8d48595b9677baaadc fix link (#714)

Branch comparison: https://github.com/gazebosim/gz-gui/compare/main...gz-gui10

**Note to maintainers**: Remember to **Rebase and Merge** with commit (not squash-merge)
