### PR TITLE
DONTMERGE: debugging resolute test failures

### DIFF
--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -60,6 +60,7 @@ TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Constructor))
   // No Qt app
   EXPECT_EQ(nullptr, qGuiApp);
   EXPECT_EQ(nullptr, App());
+  FAIL() << "Fail on purpose to see GitHub workflow console output";
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
some tests pass in github actions but fail on jenkins

the console output is not printed in github actions for passing tests, so make one test fail to print the output

please don't merge this

part of https://github.com/gazebo-tooling/release-tools/issues/1485