### PR TITLE
Fix linter warnigns found using the QT agentic skills

### DIFF
--- a/include/gz/gui/MainWindow.hh
+++ b/include/gz/gui/MainWindow.hh
@@ -598,65 +598,65 @@ namespace gz::gui
       bool IsIgnoring(const std::string &_prop) const;
 
       /// \brief Window X position in px
-      int posX{-1};
+      int posX = -1;
 
       /// \brief Window Y position in px
-      int posY{-1};
+      int posY = -1;
 
       /// \brief Window width in px
-      int width{-1};
+      int width = -1;
 
       /// \brief Window height in px
-      int height{-1};
+      int height = -1;
 
       /// \brief Window state (dock configuration)
       QByteArray state;
 
       /// \brief Material theme (light / dark)
-      std::string materialTheme{""};
+      std::string materialTheme = "";
 
       /// \brief Material primary color
-      std::string materialPrimary{""};
+      std::string materialPrimary = "";
 
       /// \brief Material accent color
-      std::string materialAccent{""};
+      std::string materialAccent = "";
 
       /// \brief Top toolbar color light
-      std::string toolBarColorLight{""};
+      std::string toolBarColorLight = "";
 
       /// \brief Top toolbar text color light
-      std::string toolBarTextColorLight{""};
+      std::string toolBarTextColorLight = "";
 
       /// \brief Top toolbar color dark
-      std::string toolBarColorDark{""};
+      std::string toolBarColorDark = "";
 
       /// \brief Top toolbar text color dark
-      std::string toolBarTextColorDark{""};
+      std::string toolBarTextColorDark = "";
 
       /// \brief Plugin toolbar color light
-      std::string pluginToolBarColorLight{""};
+      std::string pluginToolBarColorLight = "";
 
       /// \brief Plugin toolbar text color light
-      std::string pluginToolBarTextColorLight{""};
+      std::string pluginToolBarTextColorLight = "";
 
       /// \brief Plugin toolbar color dark
-      std::string pluginToolBarColorDark{""};
+      std::string pluginToolBarColorDark = "";
 
       /// \brief Plugin toolbar text color dark
-      std::string pluginToolBarTextColorDark{""};
+      std::string pluginToolBarTextColorDark = "";
 
       /// \brief Show the side drawer
-      bool showDrawer{true};
+      bool showDrawer = true;
 
       /// \brief Show the default options of the drawer
-      bool showDefaultDrawerOpts{true};
+      bool showDefaultDrawerOpts = true;
 
       /// \brief Show the plugins menu
-      bool showPluginMenu{true};
+      bool showPluginMenu = true;
 
       /// \brief True if plugins found in plugin paths should be listed under
       /// the Plugins menu. True by default.
-      bool pluginsFromPaths{true};
+      bool pluginsFromPaths = true;
 
       /// \brief List of plugins which should be shown on the list
       std::vector<std::string> showPlugins;
@@ -665,7 +665,7 @@ namespace gz::gui
       std::set<std::string> ignoredProps;
 
       /// \brief Concatenation of all plugin configurations.
-      std::string plugins{""};
+      std::string plugins = "";
     };
 }  // namespace gz::gui
 #endif  // GZ_GUI_MAINWINDOW_HH_

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -861,7 +861,7 @@ std::vector<std::pair<std::string, std::vector<std::string>>>
       // This computation could underflow the unsigned range, but that is okay
       // as in such case we would check if the suffix is placed somewhere much
       // further than allowed filename length.
-      const auto suffixPos = plugin.length() - strlen(SHARED_LIBRARY_SUFFIX);
+      const auto suffixPos = plugin.size() - strlen(SHARED_LIBRARY_SUFFIX);
 
       if (plugin.find(SHARED_LIBRARY_PREFIX) == 0 &&
           plugin.rfind(SHARED_LIBRARY_SUFFIX) == suffixPos)

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -407,7 +407,7 @@ bool Application::LoadWindowConfig(const tinyxml2::XMLElement &_winElem)
   if (auto *defaultExitActionElem =
     _winElem.FirstChildElement("default_exit_action"))
   {
-    ExitAction action{ExitAction::CLOSE_GUI};
+    ExitAction action = ExitAction::CLOSE_GUI;
     const auto value = common::lowercase(defaultExitActionElem->GetText());
     if (value == "shutdown_server")
     {
@@ -425,7 +425,7 @@ bool Application::LoadWindowConfig(const tinyxml2::XMLElement &_winElem)
   // Dialog on exit
   if (auto *dialogOnExitElem = _winElem.FirstChildElement("dialog_on_exit"))
   {
-    bool showDialogOnExit{false};
+    bool showDialogOnExit = false;
     dialogOnExitElem->QueryBoolText(&showDialogOnExit);
     this->dataPtr->mainWin->SetShowDialogOnExit(showDialogOnExit);
   }
@@ -442,14 +442,14 @@ bool Application::LoadWindowConfig(const tinyxml2::XMLElement &_winElem)
     if (auto *showShutdownElem =
       dialogOnExitOptionsElem->FirstChildElement("show_shutdown_button"))
     {
-      bool showShutdownButton{false};
+      bool showShutdownButton = false;
       showShutdownElem->QueryBoolText(&showShutdownButton);
       this->dataPtr->mainWin->SetExitDialogShowShutdown(showShutdownButton);
     }
     if (auto *showCloseGuiElem =
       dialogOnExitOptionsElem->FirstChildElement("show_close_gui_button"))
     {
-      bool showCloseGuiButton{false};
+      bool showCloseGuiButton = false;
       showCloseGuiElem->QueryBoolText(&showCloseGuiButton);
       this->dataPtr->mainWin->SetExitDialogShowCloseGui(showCloseGuiButton);
     }
@@ -468,7 +468,7 @@ bool Application::LoadWindowConfig(const tinyxml2::XMLElement &_winElem)
   }
 
   // Server control service topic
-  std::string serverControlService{"/server_control"};
+  std::string serverControlService = "/server_control";
   auto *serverControlElem =
     _winElem.FirstChildElement("server_control_service");
   if (nullptr != serverControlElem && nullptr != serverControlElem->GetText())

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -660,7 +660,7 @@ bool Application::LoadPlugin(const std::string &_filename,
 std::shared_ptr<Plugin> Application::PluginByName(
     const std::string &_pluginName) const
 {
-  for (auto &plugin : this->dataPtr->pluginsAdded)
+  for (const auto &plugin : this->dataPtr->pluginsAdded)
   {
     auto *cardItem = plugin->CardItem();
     if (!cardItem)

--- a/src/Dialog.cc
+++ b/src/Dialog.cc
@@ -95,7 +95,7 @@ bool Dialog::UpdateConfigAttribute(const std::string &_path,
   }
 
   // Update attribute value for the correct dialog
-  bool updated{false};
+  bool updated = false;
   for (auto dialogElem = doc.FirstChildElement("dialog");
     dialogElem != nullptr;
     dialogElem = dialogElem->NextSiblingElement("dialog"))

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -133,7 +133,7 @@ QStringList MainWindow::PluginListModel() const
       // Remove shared library prefix and shared library suffix
       auto pluginName = plugin.substr(
         strlen(SHARED_LIBRARY_PREFIX),
-        plugin.length() - strlen(SHARED_LIBRARY_PREFIX) -
+        plugin.size() - strlen(SHARED_LIBRARY_PREFIX) -
         strlen(SHARED_LIBRARY_SUFFIX));
 
       // Split WWWCamelCase3D -> WWW Camel Case 3D

--- a/src/PlottingInterface.cc
+++ b/src/PlottingInterface.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <chrono>
 #include <sstream>
 #include <gz/common/Console.hh>
 #include <gz/common/StringUtils.hh>
@@ -85,7 +86,7 @@ class PlottingInterface::Implementation
   public: std::shared_ptr<double> plottingTimeRef = std::make_shared<double>();
 
   /// \brief timeout to update the plot with the timer
-  public: int timeout;
+  public: std::chrono::milliseconds timeout{0};
 
   /// \brief timer to update the plotting each time step
   public: QTimer timer {nullptr};
@@ -490,7 +491,7 @@ PlottingInterface::PlottingInterface():
           SIGNAL(plot(int, QString, double, double)), this,
           SLOT(onPlot(int, QString, double, double)));
 
-  this->dataPtr->timeout = 1;
+  this->dataPtr->timeout = std::chrono::milliseconds(1);
   this->InitTimer();
 
   App()->Engine()->rootContext()->setContextProperty("_PlottingIface", this);
@@ -579,7 +580,7 @@ void PlottingInterface::onPlot(int _chart, QString _fieldID,
 //////////////////////////////////////////////////////
 void PlottingInterface::UpdateTime()
 {
-  *this->dataPtr->plottingTimeRef += this->dataPtr->timeout * 0.001;
+  *this->dataPtr->plottingTimeRef += this->dataPtr->timeout.count() * 0.001;
 }
 
 //////////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

## Summary

Found that the Qt is supplying an agentic development kit that can review cpp and QML, see the introduction in https://www.qt.io/blog/introducing-qt-agentic-development-skills.

I put my agent to work on this code and the first pass found many interesting points to improve. In this first PR I address the complains done by the linter: https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review#what-it-does.

One commit per issue detected with a meaningful commit message. I reviewed the commits and they made sense to me.

## Test it

I've build a colcon workspace with gz-gui and gz-sim and the test suite run fine on my 24.04 Ubuntu. I was also able to launch gz-sim and play with the GUI and plot just fine.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.