### PR TITLE
Fix Grid3D cmake warning on non-Linux OS

### DIFF
--- a/src/plugins/grid_config/CMakeLists.txt
+++ b/src/plugins/grid_config/CMakeLists.txt
@@ -10,11 +10,11 @@ gz_gui_add_plugin(GridConfig
 # Also install Grid3D (a legacy plugin with a subset of features) by copying the installed GridConfig library. This ensures the correct RUNPATH is used.
 
 install(CODE "
-  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig${CMAKE_SHARED_LIBRARY_SUFFIX}\")
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\"
-    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGrid3D.so\")
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig${CMAKE_SHARED_LIBRARY_SUFFIX}\"
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGrid3D${CMAKE_SHARED_LIBRARY_SUFFIX}\")
   else()
-    message(WARNING \"Source file for Grid3D (legacy plugin) copy not found, skipping copy: \${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+    message(WARNING \"Source file for Grid3D (legacy plugin) copy not found, skipping copy: \${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig${CMAKE_SHARED_LIBRARY_SUFFIX}\")
   endif()
 ")


### PR DESCRIPTION
# 🦟 Bug fix

Fixes cmake warning using suggestion from https://github.com/gazebosim/gz-gui/pull/745#discussion_r2856006548

## Summary

There is install logic with the `.so` library suffix hardcoded that doesn't work properly on macOS and Windows and generates cmake warnings. This fixes portability and the cmake warnings by using CMAKE_SHARED_LIBRARY_SUFFIX.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_gui-ci-main-homebrew-arm64&build=73)](https://build.osrfoundation.org/job/gz_gui-ci-main-homebrew-arm64/73/) https://build.osrfoundation.org/job/gz_gui-ci-main-homebrew-arm64/73/cmake/

~~~
19:18:16 -- Installing: /opt/homebrew/Cellar/gz-gui11/HEAD/lib/gz-gui/plugins/libGridConfig.dylib
19:18:16 CMake Warning at src/plugins/grid_config/cmake_install.cmake:68 (message):
19:18:16   Source file for Grid3D (legacy plugin) copy not found, skipping copy:
19:18:16   /opt/homebrew/Cellar/gz-gui11/HEAD/lib/gz-gui/plugins/libGridConfig.so
19:18:16 Call Stack (most recent call first):
19:18:16   src/plugins/cmake_install.cmake:57 (include)
19:18:16   src/cmake_install.cmake:47 (include)
19:18:16   cmake_install.cmake:42 (include)
~~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
