### PR TITLE
MinimalScene: expose raw Vulkan handles via rhiParams; enable FD-import extensions

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -155,6 +155,10 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
     qputenv("QT_VULKAN_DEVICE_EXTENSIONS",
             "VK_KHR_maintenance2;VK_EXT_shader_subgroup_vote;"
             "VK_EXT_shader_viewport_index_layer;"
+            // External memory / semaphore: required for cross-device FD import
+            // (VkImage exported by a render engine, imported onto Qt's QRhi device).
+            "VK_KHR_external_memory;VK_KHR_external_memory_fd;"
+            "VK_KHR_external_semaphore;VK_KHR_external_semaphore_fd;"
 #  ifdef GZ_USE_VULKAN_DEBUG_EXT
             ";VK_EXT_debug_marker"
 #  endif

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -727,15 +727,15 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
       // Engines using QRhi device adoption (e.g. OgreNext) continue using the
       // external_instance / external_device keys above and ignore these.
       this->dataPtr->rhiParams["vulkan_instance"] =
-        std::to_string(reinterpret_cast<uintptr_t>(externalInstance.instance));
+        std::to_string(reinterpret_cast<uintptr_t>(&externalInstance.instance));
       this->dataPtr->rhiParams["vulkan_physical_device"] =
         std::to_string(
-          reinterpret_cast<uintptr_t>(externalDevice.physicalDevice));
+          reinterpret_cast<uintptr_t>(&externalDevice.physicalDevice));
       this->dataPtr->rhiParams["vulkan_device"] =
-        std::to_string(reinterpret_cast<uintptr_t>(externalDevice.device));
+        std::to_string(reinterpret_cast<uintptr_t>(&externalDevice.device));
       this->dataPtr->rhiParams["vulkan_graphics_queue"] =
         std::to_string(
-          reinterpret_cast<uintptr_t>(externalDevice.graphicsQueue));
+          reinterpret_cast<uintptr_t>(&externalDevice.graphicsQueue));
     }
 #endif
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -721,6 +721,21 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
         std::to_string(reinterpret_cast<uintptr_t>(&externalInstance));
       this->dataPtr->rhiParams["external_device"] =
         std::to_string(reinterpret_cast<uintptr_t>(&externalDevice));
+
+      // Expose raw Vulkan handles for engines that manage their own VkDevice
+      // and import their rendered image onto Qt's device via external memory.
+      // Engines using QRhi device adoption (e.g. OgreNext) continue using the
+      // external_instance / external_device keys above and ignore these.
+      this->dataPtr->rhiParams["vulkan_instance"] =
+        std::to_string(reinterpret_cast<uintptr_t>(externalInstance.instance));
+      this->dataPtr->rhiParams["vulkan_physical_device"] =
+        std::to_string(
+          reinterpret_cast<uintptr_t>(externalDevice.physicalDevice));
+      this->dataPtr->rhiParams["vulkan_device"] =
+        std::to_string(reinterpret_cast<uintptr_t>(externalDevice.device));
+      this->dataPtr->rhiParams["vulkan_graphics_queue"] =
+        std::to_string(
+          reinterpret_cast<uintptr_t>(externalDevice.graphicsQueue));
     }
 #endif
 


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary

Publish the raw VkInstance / VkPhysicalDevice / VkDevice / VkQueue handles via rhiParams alongside the existing external_instance / external_device QRhi structs.

Engines that adopt Qt's VkDevice (e.g. OgreNext) already use the external_* struct keys; engines that manage their own VkDevice can use these handle keys to import their exported VkImage onto Qt's device via VK_KHR_external_memory_fd for zero-copy display.  Ignored by engines that do not need them.

Also enable the four Vulkan extensions required for cross-device FD import in the QT_VULKAN_DEVICE_EXTENSIONS env var that Qt reads at startup: VK_KHR_external_memory, VK_KHR_external_memory_fd, VK_KHR_external_semaphore, VK_KHR_external_semaphore_fd.

## Test it

Not an easy way to test right now, but I'll submit a custom test for Vulkan in a different PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.