### PR TITLE
Support GZ_GUI_RENDER_ENGINE_GUI_API_BACKEND env fallback

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -17,6 +17,7 @@
 
 #include <qsgrendererinterface.h>
 #include <tinyxml2.h>
+#include <cstdlib>
 #include <queue>
 
 #include <gz/common/Console.hh>
@@ -105,9 +106,19 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
 #else
   AvailableAPIs api = AvailableAPIs::OpenGL;
 #endif
-  if (_renderEngineGuiApiBackend)
+  // Backend selection: explicit C++ option first, then env var fallback,
+  // then OpenGL default.  The env var lets standalone `gz gui -c <config>`
+  // pick a backend when no CLI flag is forwarded by the caller.
+  std::string renderEngineGuiApiBackend =
+      _renderEngineGuiApiBackend ? _renderEngineGuiApiBackend : "";
+  if (renderEngineGuiApiBackend.empty())
   {
-    const std::string renderEngineGuiApiBackend = _renderEngineGuiApiBackend;
+    if (const char *envBackend =
+            std::getenv("GZ_GUI_RENDER_ENGINE_GUI_API_BACKEND"))
+      renderEngineGuiApiBackend = envBackend;
+  }
+  if (!renderEngineGuiApiBackend.empty())
+  {
     if (renderEngineGuiApiBackend == "vulkan")
       api = AvailableAPIs::Vulkan;
 #ifdef __APPLE__


### PR DESCRIPTION
# 🎉 New feature

## Summary

When the backend is not selected via the explicit C++ option (_renderEngineGuiApiBackend == nullptr), fall back to the GZ_GUI_RENDER_ENGINE_GUI_API_BACKEND environment variable before defaulting to OpenGL.

This lets tools that launch 'gz gui -c <config>' without forwarding the backend CLI flag still select an alternative backend via the environment. OpenGL remains the default when neither the option nor the env var is set; no behaviour change for existing users.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.8.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.