### PR TITLE
Protect gz-gui from loading unsupported Vulkan backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ set(GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR
 #============================================================================
 gz_configure_build(QUIT_IF_BUILD_ERRORS)
 
+# Application.cc reads GZ_RENDERING_HAVE_VULKAN from gz/rendering/config.hh at
+# compile time.
+target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE
+  $<TARGET_PROPERTY:gz-rendering::gz-rendering,INTERFACE_INCLUDE_DIRECTORIES>)
+
 #============================================================================
 # gz command line support
 #============================================================================

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -28,6 +28,10 @@
 
 #include <gz/plugin/Loader.hh>
 
+// For GZ_RENDERING_HAVE_VULKAN: only switch the Qt scene graph to Vulkan when
+// the rendering stack actually has Vulkan support compiled in.
+#include <gz/rendering/config.hh>
+
 #include "gz/gui/Application.hh"
 #include "gz/gui/config.hh"
 #include "gz/gui/Dialog.hh"
@@ -115,6 +119,23 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
       api = AvailableAPIs::Metal;
 #endif
   }
+
+  // If the requested API is not actually available in this build, fall back to
+  // OpenGL *before* the Qt scene graph backend and the
+  // "renderEngineBackendApiName" window property are derived from `api`. This
+  // keeps the whole GUI stack consistent (Qt scene graph + the render interface
+  // the MinimalScene plugin creates). Requesting a backend that was not built
+  // in (e.g. Vulkan when gz-rendering/gz-gui were built without Vulkan support)
+  // would otherwise leave the render interface null and crash during init.
+#if !(defined(GZ_RENDERING_HAVE_VULKAN) && QT_CONFIG(vulkan))
+  if (api == AvailableAPIs::Vulkan)
+  {
+    gzerr << "Vulkan GUI graphics backend was requested but this build has no "
+          << "Vulkan support. Rebuild gz-rendering and gz-gui with Vulkan "
+          << "support to use it. Falling back to OpenGL." << std::endl;
+    api = AvailableAPIs::OpenGL;
+  }
+#endif
 
 #ifdef __APPLE__
   if (api == AvailableAPIs::Metal)

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1013,11 +1013,45 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
     this->rhi = std::make_unique<RenderThreadRhiMetal>(&this->gzRenderer);
   }
 #endif  // GZ_GUI_HAVE_METAL
+
+  // Safety net: if the requested backend's render interface was not compiled
+  // into this build (e.g. Vulkan requested but gz-gui was built without Vulkan
+  // support, GZ_GUI_HAVE_VULKAN == 0), none of the branches above run and
+  // this->rhi stays null. RenderThread::Initialize() would then dereference a
+  // null pointer and crash.
+  //
+  // Fall back to OpenGL. gz::gui::Application applies the same fallback to the
+  // Qt scene graph when Vulkan is unavailable, so the OpenGL context and the Qt
+  // scene graph stay consistent (an OpenGL interface under a Vulkan scene graph
+  // would crash in QOpenGLContext::makeCurrent()).
+  if (nullptr == this->rhi)
+  {
+    gzerr << "GUI render backend ["
+          << rendering::GraphicsAPIUtils::Str(_graphicsAPI)
+          << "] is not available in this gz-gui build. Falling back to OpenGL. "
+          << "Rebuild gz-rendering and gz-gui with Vulkan support to use it."
+          << std::endl;
+    this->gzRenderer.SetGraphicsAPI(rendering::GraphicsAPI::OPENGL);
+    this->rhi = std::make_unique<RenderThreadRhiOpenGL>(&this->gzRenderer);
+  }
 }
 
 /////////////////////////////////////////////////
 std::string RenderThread::Initialize()
 {
+  // Defense in depth: if SetGraphicsAPI() could not create a render interface
+  // for the requested backend (unavailable in this build), report a clean error
+  // instead of dereferencing a null pointer. RenderWindowItem::Ready() checks
+  // this return value and aborts initialization, so the GUI stays alive.
+  if (nullptr == this->rhi)
+  {
+    const std::string err = "GUI render interface not initialized: the "
+        "requested graphics backend is unavailable in this build.";
+    if (this->errorCb)
+      this->errorCb(QString::fromStdString(err));
+    return err;
+  }
+
   auto loadingError = this->rhi->Initialize();
   if (!loadingError.empty())
   {

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1017,14 +1017,13 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
   // Safety net: if the requested backend's render interface was not compiled
   // into this build (e.g. Vulkan requested but gz-gui was built without Vulkan
   // support, GZ_GUI_HAVE_VULKAN == 0), none of the branches above run and
-  // this->rhi stays null. RenderThread::Initialize() would then dereference a
-  // null pointer and crash.
+  // this->rhi stays null.
   //
   // Fall back to OpenGL. gz::gui::Application applies the same fallback to the
   // Qt scene graph when Vulkan is unavailable, so the OpenGL context and the Qt
   // scene graph stay consistent (an OpenGL interface under a Vulkan scene graph
   // would crash in QOpenGLContext::makeCurrent()).
-  if (nullptr == this->rhi)
+  if (this->rhi == nullptr)
   {
     gzerr << "GUI render backend ["
           << rendering::GraphicsAPIUtils::Str(_graphicsAPI)
@@ -1039,11 +1038,11 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
 /////////////////////////////////////////////////
 std::string RenderThread::Initialize()
 {
-  // Defense in depth: if SetGraphicsAPI() could not create a render interface
-  // for the requested backend (unavailable in this build), report a clean error
-  // instead of dereferencing a null pointer. RenderWindowItem::Ready() checks
-  // this return value and aborts initialization, so the GUI stays alive.
-  if (nullptr == this->rhi)
+  // If SetGraphicsAPI() could not create a render interface for the requested
+  // backend (unavailable in this build), report a clean error instead of
+  // dereferencing a null pointer. RenderWindowItem::Ready() checks this return
+  // value and aborts initialization, so the GUI stays alive.
+  if (this->rhi == nullptr)
   {
     const std::string err = "GUI render interface not initialized: the "
         "requested graphics backend is unavailable in this build.";


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-sim/issues/3716

## Summary

gz-gui crashes with a null-pointer dereference when the Vulkan graphics backend is requested at runtime but gz-gui and/or gz-rendering were built without Vulkan support. This PR adds two layers of protection so the GUI falls back to OpenGL gracefully and emits a clear error instead of crashing.

**Changes:**

* **`Application.cc`** — before the Qt scene graph backend is selected, checks the compile-time flags `GZ_RENDERING_HAVE_VULKAN` (from `gz/rendering/config.hh`) and `QT_CONFIG(vulkan)`. If either is absent, overrides the requested API to OpenGL with an explanatory `gzerr` message.

* **`MinimalScene.cc` / `RenderThread::SetGraphicsAPI()`** — after the `#ifdef GZ_GUI_HAVE_VULKAN` / `#ifdef GZ_GUI_HAVE_METAL` chain, adds a safety net: if `this->rhi` is still null (the requested backend was not compiled in), falls back to OpenGL and logs the error. This keeps the render interface and the Qt scene graph backend consistent (an OpenGL RHI under a Vulkan scene graph would crash in `QOpenGLContext::makeCurrent()`).

* **`MinimalScene.cc` / `RenderThread::Initialize()`** — adds a null-check on `this->rhi` before dereferencing it, returning a clean error string that `RenderWindowItem::Ready()` can surface instead of crashing.

* **`CMakeLists.txt`** — propagates `gz-rendering`'s include directories to the core gz-gui library target so `Application.cc` can resolve `gz/rendering/config.hh` at compile time.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? Yes — `Generated-by: Claude Opus 4.8` tags present on commits.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.